### PR TITLE
[Refactor]: 拆分客户端配置并增加预览渲染开关

### DIFF
--- a/src/main/java/club/heiqi/qz_miner/Config.java
+++ b/src/main/java/club/heiqi/qz_miner/Config.java
@@ -10,6 +10,8 @@ import net.minecraftforge.common.config.Configuration;
 
 public class Config {
 
+    public static final String CATEGORY_CLIENT = "client";
+
     public static String configPath;
     public static Configuration config;
     public static String greeting = "Hello World";
@@ -18,6 +20,7 @@ public class Config {
     public static int chainLoggingShellLayers = 1;
     public static int maxBreakPerTick = 16;
     public static int parallelTickMinDurationMs = 15;
+    public static boolean clientEnablePreviewRender = true;
     public static int clientPreviewMaxRadius = 4;
     public static int clientPreviewMaxTargets = 256;
     public static double clientPreviewAlphaFadeStartRadius = 2.0D;
@@ -51,12 +54,13 @@ public class Config {
         chainLoggingShellLayers = config.getInt("chainLoggingShellLayers", Configuration.CATEGORY_GENERAL, chainLoggingShellLayers, 1, Integer.MAX_VALUE, "CHAIN 伐木子模式每次向外扩展的壳层数；1 表示围绕当前原木检查一圈 3x3x3 邻域");
         maxBreakPerTick = config.getInt("maxBreakPerTick", Configuration.CATEGORY_GENERAL, maxBreakPerTick, 1, Integer.MAX_VALUE, "每 Tick 最多执行的连锁挖掘数量");
         parallelTickMinDurationMs = config.getInt("parallelTickMinDurationMs", Configuration.CATEGORY_GENERAL, parallelTickMinDurationMs, 10, Integer.MAX_VALUE, "同步执行器每刻最短执行时间（毫秒），默认 15，最低 10");
-        clientPreviewMaxRadius = config.getInt("clientPreviewMaxRadius", Configuration.CATEGORY_GENERAL, clientPreviewMaxRadius, 1, Integer.MAX_VALUE, "客户端最大预览半径；实际预览范围取该值与 chainRadius 的较小值，避免大范围预览渲染导致卡顿");
-        clientPreviewMaxTargets = config.getInt("clientPreviewMaxTargets", Configuration.CATEGORY_GENERAL, clientPreviewMaxTargets, 1, Integer.MAX_VALUE, "客户端最大预览目标数量；实际预览数量取该值与服务端 chainMaxBlocks 的较小值，避免大范围预览导致卡顿");
-        clientPreviewAlphaFadeStartRadius = config.get(Configuration.CATEGORY_GENERAL, "clientPreviewAlphaFadeStartRadius", clientPreviewAlphaFadeStartRadius, "客户端预览透明度开始衰减的距离半径；在此半径内保持最高透明度").getDouble(clientPreviewAlphaFadeStartRadius);
-        clientPreviewAlphaFadeEndRadius = config.get(Configuration.CATEGORY_GENERAL, "clientPreviewAlphaFadeEndRadius", clientPreviewAlphaFadeEndRadius, "客户端预览透明度衰减到最低值的距离半径；超过该半径后保持最低透明度").getDouble(clientPreviewAlphaFadeEndRadius);
-        clientPreviewAlphaStartValue = config.get(Configuration.CATEGORY_GENERAL, "clientPreviewAlphaStartValue", clientPreviewAlphaStartValue, "客户端预览透明度的起始值；距离不超过衰减起点时使用该透明度").getDouble(clientPreviewAlphaStartValue);
-        clientPreviewAlphaEndValue = config.get(Configuration.CATEGORY_GENERAL, "clientPreviewAlphaEndValue", clientPreviewAlphaEndValue, "客户端预览透明度的结束值；距离超过衰减终点时使用该透明度").getDouble(clientPreviewAlphaEndValue);
+        clientEnablePreviewRender = config.getBoolean("clientEnablePreviewRender", CATEGORY_CLIENT, clientEnablePreviewRender, "是否启用客户端连锁预览计算与渲染；关闭后将不再执行任何预览相关渲染操作");
+        clientPreviewMaxRadius = config.getInt("clientPreviewMaxRadius", CATEGORY_CLIENT, clientPreviewMaxRadius, 1, Integer.MAX_VALUE, "客户端最大预览半径；实际预览范围取该值与 chainRadius 的较小值，避免大范围预览渲染导致卡顿");
+        clientPreviewMaxTargets = config.getInt("clientPreviewMaxTargets", CATEGORY_CLIENT, clientPreviewMaxTargets, 1, Integer.MAX_VALUE, "客户端最大预览目标数量；实际预览数量取该值与服务端 chainMaxBlocks 的较小值，避免大范围预览导致卡顿");
+        clientPreviewAlphaFadeStartRadius = config.get(CATEGORY_CLIENT, "clientPreviewAlphaFadeStartRadius", clientPreviewAlphaFadeStartRadius, "客户端预览透明度开始衰减的距离半径；在此半径内保持最高透明度").getDouble(clientPreviewAlphaFadeStartRadius);
+        clientPreviewAlphaFadeEndRadius = config.get(CATEGORY_CLIENT, "clientPreviewAlphaFadeEndRadius", clientPreviewAlphaFadeEndRadius, "客户端预览透明度衰减到最低值的距离半径；超过该半径后保持最低透明度").getDouble(clientPreviewAlphaFadeEndRadius);
+        clientPreviewAlphaStartValue = config.get(CATEGORY_CLIENT, "clientPreviewAlphaStartValue", clientPreviewAlphaStartValue, "客户端预览透明度的起始值；距离不超过衰减起点时使用该透明度").getDouble(clientPreviewAlphaStartValue);
+        clientPreviewAlphaEndValue = config.get(CATEGORY_CLIENT, "clientPreviewAlphaEndValue", clientPreviewAlphaEndValue, "客户端预览透明度的结束值；距离超过衰减终点时使用该透明度").getDouble(clientPreviewAlphaEndValue);
         clientPreviewAlphaFadeStartRadius = Math.max(0.0D, clientPreviewAlphaFadeStartRadius);
         clientPreviewAlphaFadeEndRadius = Math.max(clientPreviewAlphaFadeStartRadius + 0.001D, clientPreviewAlphaFadeEndRadius);
         clientPreviewAlphaStartValue = Math.max(0.0D, Math.min(1.0D, clientPreviewAlphaStartValue));

--- a/src/main/java/club/heiqi/qz_miner/chain/client/ChainPreviewController.java
+++ b/src/main/java/club/heiqi/qz_miner/chain/client/ChainPreviewController.java
@@ -69,6 +69,11 @@ public class ChainPreviewController {
             return;
         }
 
+        if (!Config.clientEnablePreviewRender) {
+            stopPreview();
+            return;
+        }
+
         if (!MyMod.chainStateService.getClientState().isChainKeyPressed()) {
             stopPreview();
             return;
@@ -177,6 +182,10 @@ public class ChainPreviewController {
      * @return 预览半径
      */
     public int getEffectivePreviewRadius() {
+        if (!Config.clientEnablePreviewRender) {
+            return 1;
+        }
+
         int serverChainRadius = MyMod.chainStateService == null
             ? Config.chainRadius
             : MyMod.chainStateService.getClientState().getServerChainRadius();
@@ -189,6 +198,10 @@ public class ChainPreviewController {
      * @return 预览目标数量上限
      */
     public int getEffectivePreviewMaxTargets() {
+        if (!Config.clientEnablePreviewRender) {
+            return 1;
+        }
+
         int serverChainMaxBlocks = MyMod.chainStateService == null
             ? Config.chainMaxBlocks
             : MyMod.chainStateService.getClientState().getServerChainMaxBlocks();

--- a/src/main/java/club/heiqi/qz_miner/chain/client/ChainPreviewRenderer.java
+++ b/src/main/java/club/heiqi/qz_miner/chain/client/ChainPreviewRenderer.java
@@ -3,6 +3,7 @@ package club.heiqi.qz_miner.chain.client;
 import java.util.List;
 
 import club.heiqi.qz_miner.ClientProxy;
+import club.heiqi.qz_miner.Config;
 import club.heiqi.qz_miner.MyMod;
 import club.heiqi.qz_miner.chain.planner.ChainTarget;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
@@ -43,6 +44,10 @@ public class ChainPreviewRenderer {
     public void onRenderWorldLast(RenderWorldLastEvent event) {
         Minecraft minecraft = Minecraft.getMinecraft();
         if (minecraft == null || minecraft.theWorld == null || minecraft.thePlayer == null) {
+            clearMesh();
+            return;
+        }
+        if (!Config.clientEnablePreviewRender) {
             clearMesh();
             return;
         }

--- a/src/main/java/club/heiqi/qz_miner/client/configGUI/QzMinerConfigGUI.java
+++ b/src/main/java/club/heiqi/qz_miner/client/configGUI/QzMinerConfigGUI.java
@@ -29,7 +29,7 @@ public class QzMinerConfigGUI extends GuiConfig {
     private static List<IConfigElement> getConfigElements() {
         List<IConfigElement> elements = new ArrayList<>();
 
-        for (String categoryName : Arrays.asList(Configuration.CATEGORY_GENERAL)) {
+        for (String categoryName : Arrays.asList(Configuration.CATEGORY_GENERAL, Config.CATEGORY_CLIENT)) {
             ConfigCategory category = Config.config.getCategory(categoryName);
             elements.add(new ConfigElement(category));
         }


### PR DESCRIPTION
将客户端预览相关配置从通用配置中拆出，独立放入 client 分类，并同步更新配置 GUI 展示。

新增 clientEnablePreviewRender 开关，关闭后直接停止客户端预览计算与渲染链路，避免继续执行任何预览相关渲染操作。