### PR TITLE
[Fix]: 移除伐木模式的最大半径限制

### DIFF
--- a/src/main/java/club/heiqi/qz_miner/chain/planner/LoggingFloodFillTraverser.java
+++ b/src/main/java/club/heiqi/qz_miner/chain/planner/LoggingFloodFillTraverser.java
@@ -75,10 +75,6 @@ public class LoggingFloodFillTraverser implements ChainTraverser {
                 continue;
             }
 
-            if (getDistance(next, context.getOrigin()) > context.getMaxRadius()) {
-                continue;
-            }
-
             if (!context.canTraverse(next)) {
                 continue;
             }
@@ -106,12 +102,5 @@ public class LoggingFloodFillTraverser implements ChainTraverser {
             }
         }
         return offsets;
-    }
-
-    private static int getDistance(ChainTarget a, ChainTarget b) {
-        int dx = Math.abs(a.getX() - b.getX());
-        int dy = Math.abs(a.getY() - b.getY());
-        int dz = Math.abs(a.getZ() - b.getZ());
-        return Math.max(dx, Math.max(dy, dz));
     }
 }


### PR DESCRIPTION
修复 #212，使 CHAIN 伐木子模式在壳层扩张时不再受最大半径限制，只保留最大数量上限作为停止条件。

其他模式仍保持原有半径限制逻辑不变。