### PR TITLE
[Add]: 接入 LootGames 扫雷预览并修复时运 Mixin

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -39,6 +39,7 @@ dependencies {
     }
 
     implementation(project.elytraModpackVersion.gtnhdev("GT5-Unofficial"))
+    implementation(project.elytraModpackVersion.gtnhdev("LootGames"))
     implementation(project.elytraModpackVersion.gtnhdev("GTNHLib"))
     implementation(project.elytraModpackVersion.gtnhdev("NewHorizonsCoreMod"))
     implementation(project.elytraModpackVersion.gtnhdev("Hodgepodge"))

--- a/src/main/java/club/heiqi/qz_miner/chain/client/ChainPreviewController.java
+++ b/src/main/java/club/heiqi/qz_miner/chain/client/ChainPreviewController.java
@@ -2,7 +2,9 @@ package club.heiqi.qz_miner.chain.client;
 
 import club.heiqi.qz_miner.Config;
 import club.heiqi.qz_miner.MyMod;
+import club.heiqi.qz_miner.compat.lootgames.LootGamesMinesweeperHelper;
 import club.heiqi.qz_miner.chain.mode.ChainMode;
+import club.heiqi.qz_miner.chain.mode.ChainSubMode;
 import club.heiqi.qz_miner.chain.planner.AxisAlignedTunnelDirection;
 import club.heiqi.qz_miner.chain.planner.BlockSeedSnapshot;
 import club.heiqi.qz_miner.chain.planner.ChainBlockMatcher;
@@ -13,6 +15,7 @@ import club.heiqi.qz_miner.chain.planner.ChainTarget;
 import club.heiqi.qz_miner.chain.planner.ChainTraverser;
 import club.heiqi.qz_miner.chain.state.ChainExecutionStatus;
 import club.heiqi.qz_miner.chain.state.ChainSession;
+import club.heiqi.qz_miner.network.PacketLootGamesMinesweeperPreviewRequest;
 import club.heiqi.qz_miner.parallel.ParallelTickSubscription;
 import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
@@ -42,6 +45,7 @@ public class ChainPreviewController {
     private final ChainPreviewState previewState = new ChainPreviewState();
     private ChainTarget currentTarget;
     private ParallelTickSubscription previewTaskSubscription;
+    private int specialPreviewRequestId;
 
     public void register() {
         FMLCommonHandler.instance().bus().register(this);
@@ -116,10 +120,15 @@ public class ChainPreviewController {
         final int previewRadius = getEffectivePreviewRadius();
         final int previewMaxTargets = getEffectivePreviewMaxTargets();
         final ChainMode selectedMode = MyMod.chainStateService.getClientState().getSelectedMode();
+        final ChainSubMode selectedSubMode = MyMod.chainStateService.getClientState().getSelectedSubMode();
+        if (selectedMode == ChainMode.SPECIAL && selectedSubMode == ChainSubMode.SPECIAL_LOOTGAMES_MINESWEEPER) {
+            startLootGamesMinesweeperPreview(world, target, previewRadius, previewMaxTargets);
+            return;
+        }
         final ChainSession previewSession = new ChainSession(
             player.getUniqueID(),
             selectedMode,
-            MyMod.chainStateService.getClientState().getSelectedSubMode(),
+            selectedSubMode,
             target,
             AxisAlignedTunnelDirection.resolveFace(player));
         final BlockSeedSnapshot seedSnapshot = new BlockSeedSnapshot(target, sampleBlock, sampleMeta, sampleTileEntity);
@@ -170,6 +179,53 @@ public class ChainPreviewController {
             });
 
         MyMod.LOG.debug("[ChainPreview] Started preview for target ({}, {}, {})", target.getX(), target.getY(), target.getZ());
+    }
+
+    private void startLootGamesMinesweeperPreview(World world, ChainTarget target, int previewRadius, int previewMaxTargets) {
+        if (!LootGamesMinesweeperHelper.isMinesweeperTarget(world, target) || MyMod.networkMain == null) {
+            previewState.setCompleted(true);
+            return;
+        }
+
+        specialPreviewRequestId++;
+        MyMod.networkMain.network.sendToServer(
+            new PacketLootGamesMinesweeperPreviewRequest(specialPreviewRequestId, target, previewRadius, previewMaxTargets));
+        MyMod.LOG.debug(
+            "[ChainPreview] Requested LootGames minesweeper preview for ({}, {}, {}) radius={} maxTargets={} requestId={}",
+            target.getX(),
+            target.getY(),
+            target.getZ(),
+            previewRadius,
+            previewMaxTargets,
+            specialPreviewRequestId);
+    }
+
+    /**
+     * 应用 LootGames 扫雷预览结果。
+     *
+     * @param requestId 请求编号
+     * @param origin 请求原点
+     * @param targets 服务端返回的雷坐标
+     */
+    public void applyLootGamesMinesweeperPreview(int requestId, ChainTarget origin, java.util.List<ChainTarget> targets) {
+        if (requestId != specialPreviewRequestId
+            || currentTarget == null
+            || !currentTarget.equals(origin)
+            || !previewState.isActive()) {
+            return;
+        }
+
+        for (ChainTarget target : targets) {
+            previewState.addPreviewTarget(target);
+        }
+        previewState.setCompleted(true);
+        MyMod.LOG.debug(
+            "[ChainPreview] Applied LootGames minesweeper preview for ({}, {}, {}) targets={} requestId={}",
+            origin.getX(),
+            origin.getY(),
+            origin.getZ(),
+            targets.size(),
+            requestId);
     }
 
     /**
@@ -247,6 +303,7 @@ public class ChainPreviewController {
 
         previewState.clear();
         currentTarget = null;
+        specialPreviewRequestId++;
         if (MyMod.chainStateService != null) {
             MyMod.chainStateService.getClientState().setPreviewActive(false);
         }

--- a/src/main/java/club/heiqi/qz_miner/chain/mode/ChainModeBootstrap.java
+++ b/src/main/java/club/heiqi/qz_miner/chain/mode/ChainModeBootstrap.java
@@ -194,7 +194,7 @@ public final class ChainModeBootstrap {
             HARVESTABLE_MATCHER,
             false,
             null,
-            ChainSubMode.SPECIAL_BASE,
-            Arrays.asList(ChainSubMode.SPECIAL_BASE, ChainSubMode.SPECIAL_EXTENDED));
+            ChainSubMode.SPECIAL_LOOTGAMES_MINESWEEPER,
+            Arrays.asList(ChainSubMode.SPECIAL_LOOTGAMES_MINESWEEPER, ChainSubMode.SPECIAL_BASE, ChainSubMode.SPECIAL_EXTENDED));
     }
 }

--- a/src/main/java/club/heiqi/qz_miner/chain/mode/ChainSubMode.java
+++ b/src/main/java/club/heiqi/qz_miner/chain/mode/ChainSubMode.java
@@ -41,6 +41,10 @@ public enum ChainSubMode {
      */
     INTERACT_CROP(ChainMode.INTERACT, false, false, false),
     /**
+     * SPECIAL LootGames 扫雷预览子模式。
+     */
+    SPECIAL_LOOTGAMES_MINESWEEPER(ChainMode.SPECIAL, false, false, false),
+    /**
      * SPECIAL 默认子模式。
      */
     SPECIAL_BASE(ChainMode.SPECIAL, true, false, false),
@@ -126,6 +130,8 @@ public enum ChainSubMode {
                 return "hud.qz_miner.sub_mode.interact.base";
             case INTERACT_CROP:
                 return "hud.qz_miner.sub_mode.interact.crop";
+            case SPECIAL_LOOTGAMES_MINESWEEPER:
+                return "hud.qz_miner.sub_mode.special.lootgames_minesweeper";
             case SPECIAL_BASE:
                 return "hud.qz_miner.sub_mode.special.base";
             case SPECIAL_EXTENDED:

--- a/src/main/java/club/heiqi/qz_miner/compat/lootgames/LootGamesMinesweeperHelper.java
+++ b/src/main/java/club/heiqi/qz_miner/compat/lootgames/LootGamesMinesweeperHelper.java
@@ -1,0 +1,121 @@
+package club.heiqi.qz_miner.compat.lootgames;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import javax.annotation.Nullable;
+
+import club.heiqi.qz_miner.chain.planner.ChainTarget;
+import net.minecraft.block.Block;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.world.World;
+import ru.timeconqueror.lootgames.api.block.BoardBorderBlock;
+import ru.timeconqueror.lootgames.api.block.SmartSubordinateBlock;
+import ru.timeconqueror.lootgames.common.block.tile.MSMasterTile;
+import ru.timeconqueror.lootgames.minigame.minesweeper.GameMineSweeper;
+import ru.timeconqueror.lootgames.minigame.minesweeper.MSBoard;
+import ru.timeconqueror.lootgames.minigame.minesweeper.Type;
+import ru.timeconqueror.lootgames.utils.future.BlockPos;
+import ru.timeconqueror.lootgames.utils.future.BlockState;
+
+/**
+ * LootGames 扫雷兼容工具。
+ */
+public final class LootGamesMinesweeperHelper {
+
+    private LootGamesMinesweeperHelper() {}
+
+    /**
+     * 判断当前瞄准方块是否属于扫雷棋盘。
+     *
+     * @param world 当前世界
+     * @param target 当前瞄准坐标
+     * @return 是否属于扫雷棋盘
+     */
+    public static boolean isMinesweeperTarget(World world, ChainTarget target) {
+        return resolveMasterTile(world, target) != null;
+    }
+
+    /**
+     * 收集指定扫描半径内的雷方块坐标。
+     *
+     * @param world 当前世界
+     * @param target 当前瞄准坐标
+     * @param radius 扫描半径
+     * @param maxTargets 最大返回数量
+     * @return 雷方块坐标列表
+     */
+    public static List<ChainTarget> collectBombTargets(World world, ChainTarget target, int radius, int maxTargets) {
+        MSMasterTile masterTile = resolveMasterTile(world, target);
+        if (masterTile == null) {
+            return Collections.emptyList();
+        }
+
+        GameMineSweeper game = masterTile.getGame();
+        if (game == null || !game.isBoardGenerated()) {
+            return Collections.emptyList();
+        }
+
+        MSBoard board = game.getBoard();
+        int boardSize = board.size();
+        int cappedMaxTargets = Math.max(1, maxTargets);
+        List<ChainTarget> result = new ArrayList<ChainTarget>(Math.min(boardSize * boardSize, cappedMaxTargets));
+
+        for (int x = 0; x < boardSize && result.size() < cappedMaxTargets; x++) {
+            for (int y = 0; y < boardSize && result.size() < cappedMaxTargets; y++) {
+                if (board.getType(x, y) != Type.BOMB) {
+                    continue;
+                }
+
+                BlockPos bombPos = game.convertToBlockPos(new ru.timeconqueror.lootgames.api.util.Pos2i(x, y));
+                if (!isWithinPreviewRadius(target, bombPos, radius)) {
+                    continue;
+                }
+
+                result.add(new ChainTarget(bombPos.getX(), bombPos.getY(), bombPos.getZ()));
+            }
+        }
+
+        return result;
+    }
+
+    private static boolean isWithinPreviewRadius(ChainTarget target, BlockPos blockPos, int radius) {
+        return Math.abs(blockPos.getX() - target.getX()) <= radius
+            && Math.abs(blockPos.getY() - target.getY()) <= radius
+            && Math.abs(blockPos.getZ() - target.getZ()) <= radius;
+    }
+
+    @Nullable
+    private static MSMasterTile resolveMasterTile(World world, ChainTarget target) {
+        if (world == null || target == null) {
+            return null;
+        }
+
+        TileEntity tileEntity = world.getTileEntity(target.getX(), target.getY(), target.getZ());
+        if (tileEntity instanceof MSMasterTile) {
+            return (MSMasterTile) tileEntity;
+        }
+
+        Block block = world.getBlock(target.getX(), target.getY(), target.getZ());
+        if (block == null) {
+            return null;
+        }
+
+        BlockPos pos = BlockPos.of(target.getX(), target.getY(), target.getZ());
+        BlockPos masterPos = null;
+        if (block instanceof SmartSubordinateBlock) {
+            masterPos = SmartSubordinateBlock.getMasterPos(world, pos);
+        } else if (block instanceof BoardBorderBlock) {
+            int meta = world.getBlockMetadata(target.getX(), target.getY(), target.getZ());
+            masterPos = BoardBorderBlock.getMasterPos(world, pos, BlockState.of(block, meta));
+        }
+
+        if (masterPos == null) {
+            return null;
+        }
+
+        TileEntity masterTile = world.getTileEntity(masterPos.getX(), masterPos.getY(), masterPos.getZ());
+        return masterTile instanceof MSMasterTile ? (MSMasterTile) masterTile : null;
+    }
+}

--- a/src/main/java/club/heiqi/qz_miner/mixins/MixinBWTileEntityMetaGeneratedOre.java
+++ b/src/main/java/club/heiqi/qz_miner/mixins/MixinBWTileEntityMetaGeneratedOre.java
@@ -2,9 +2,9 @@ package club.heiqi.qz_miner.mixins;
 
 import bartworks.system.material.BWTileEntityMetaGeneratedOre;
 import club.heiqi.qz_miner.compat.FortuneCompatHelper;
+import java.util.Random;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.ModifyArg;
 import org.spongepowered.asm.mixin.injection.Redirect;
 
 /**
@@ -29,15 +29,15 @@ public abstract class MixinBWTileEntityMetaGeneratedOre {
     /**
      * 按配置解除 BW 普通矿时运 3 级上限。
      *
+     * @param random 随机数实例
      * @param currentBound 原始随机上界
      * @param fortune 原始时运等级
-     * @return 调整后的随机上界
+     * @return 调整后的随机结果
      */
-    @ModifyArg(
+    @Redirect(
         method = "getDrops(I)Ljava/util/ArrayList;",
-        at = @At(value = "INVOKE", target = "Ljava/util/Random;nextInt(I)I", ordinal = 0),
-        index = 0)
-    private int qzMiner$removeOreFortuneCap(int currentBound, int fortune) {
-        return FortuneCompatHelper.resolveCommonOreFortuneRollBound(currentBound, fortune);
+        at = @At(value = "INVOKE", target = "Ljava/util/Random;nextInt(I)I", ordinal = 0))
+    private int qzMiner$removeOreFortuneCap(Random random, int currentBound, int fortune) {
+        return random.nextInt(FortuneCompatHelper.resolveCommonOreFortuneRollBound(currentBound, fortune));
     }
 }

--- a/src/main/java/club/heiqi/qz_miner/mixins/MixinBlockBaseOre.java
+++ b/src/main/java/club/heiqi/qz_miner/mixins/MixinBlockBaseOre.java
@@ -2,10 +2,11 @@ package club.heiqi.qz_miner.mixins;
 
 import club.heiqi.qz_miner.compat.FortuneCompatHelper;
 import gtPlusPlus.core.block.base.BlockBaseOre;
+import java.util.Random;
 import net.minecraft.world.World;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.ModifyArg;
+import org.spongepowered.asm.mixin.injection.Redirect;
 
 /**
  * 调整 GT++ 普通矿时运上限。
@@ -16,6 +17,7 @@ public abstract class MixinBlockBaseOre {
     /**
      * 按配置解除 GT++ 普通矿时运 3 级上限。
      *
+     * @param random 随机数实例
      * @param currentBound 原始随机上界
      * @param world 世界对象
      * @param x 方块坐标 X
@@ -23,13 +25,12 @@ public abstract class MixinBlockBaseOre {
      * @param z 方块坐标 Z
      * @param metadata 方块元数据
      * @param fortune 原始时运等级
-     * @return 调整后的随机上界
+     * @return 调整后的随机结果
      */
-    @ModifyArg(
+    @Redirect(
         method = "getDrops(Lnet/minecraft/world/World;IIIII)Ljava/util/ArrayList;",
-        at = @At(value = "INVOKE", target = "Ljava/util/Random;nextInt(I)I", ordinal = 0),
-        index = 0)
-    private int qzMiner$removeOreFortuneCap(int currentBound, World world, int x, int y, int z, int metadata, int fortune) {
-        return FortuneCompatHelper.resolveCommonOreFortuneRollBound(currentBound, fortune);
+        at = @At(value = "INVOKE", target = "Ljava/util/Random;nextInt(I)I", ordinal = 0))
+    private int qzMiner$removeOreFortuneCap(Random random, int currentBound, World world, int x, int y, int z, int metadata, int fortune) {
+        return random.nextInt(FortuneCompatHelper.resolveCommonOreFortuneRollBound(currentBound, fortune));
     }
 }

--- a/src/main/java/club/heiqi/qz_miner/mixins/MixinTileEntityOres.java
+++ b/src/main/java/club/heiqi/qz_miner/mixins/MixinTileEntityOres.java
@@ -2,11 +2,10 @@ package club.heiqi.qz_miner.mixins;
 
 import club.heiqi.qz_miner.compat.FortuneCompatHelper;
 import gregtech.common.blocks.TileEntityOres;
-import net.minecraft.block.Block;
+import java.util.Random;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.ModifyArg;
 import org.spongepowered.asm.mixin.injection.Redirect;
 
 /**
@@ -47,16 +46,16 @@ public abstract class MixinTileEntityOres {
     /**
      * 按配置解除 GT 普通矿时运 3 级上限。
      *
+     * @param random 随机数实例
      * @param currentBound 原始随机上界
      * @param droppedOre 掉落方块
      * @param fortune 原始时运等级
-     * @return 调整后的随机上界
+     * @return 调整后的随机结果
      */
-    @ModifyArg(
+    @Redirect(
         method = "getDrops(Lnet/minecraft/block/Block;I)Ljava/util/ArrayList;",
-        at = @At(value = "INVOKE", target = "Ljava/util/Random;nextInt(I)I", ordinal = 0),
-        index = 0)
-    private int qzMiner$removeNormalOreFortuneCap(int currentBound, Block droppedOre, int fortune) {
-        return FortuneCompatHelper.resolveGtOreFortuneRollBound(currentBound, fortune);
+        at = @At(value = "INVOKE", target = "Ljava/util/Random;nextInt(I)I", ordinal = 0))
+    private int qzMiner$removeNormalOreFortuneCap(Random random, int currentBound, net.minecraft.block.Block droppedOre, int fortune) {
+        return random.nextInt(FortuneCompatHelper.resolveGtOreFortuneRollBound(currentBound, fortune));
     }
 }

--- a/src/main/java/club/heiqi/qz_miner/network/NetworkMain.java
+++ b/src/main/java/club/heiqi/qz_miner/network/NetworkMain.java
@@ -45,5 +45,15 @@ public final class NetworkMain {
                 PacketChainStateSync.class,
                 packetId++,
                 Side.CLIENT);
+        network.registerMessage(
+                PacketLootGamesMinesweeperPreviewRequest.Handler.class,
+                PacketLootGamesMinesweeperPreviewRequest.class,
+                packetId++,
+                Side.SERVER);
+        network.registerMessage(
+                PacketLootGamesMinesweeperPreviewResponse.Handler.class,
+                PacketLootGamesMinesweeperPreviewResponse.class,
+                packetId++,
+                Side.CLIENT);
     }
 }

--- a/src/main/java/club/heiqi/qz_miner/network/PacketLootGamesMinesweeperPreviewRequest.java
+++ b/src/main/java/club/heiqi/qz_miner/network/PacketLootGamesMinesweeperPreviewRequest.java
@@ -1,0 +1,80 @@
+package club.heiqi.qz_miner.network;
+
+import java.util.List;
+
+import club.heiqi.qz_miner.MyMod;
+import club.heiqi.qz_miner.compat.lootgames.LootGamesMinesweeperHelper;
+import club.heiqi.qz_miner.chain.planner.ChainTarget;
+import cpw.mods.fml.common.FMLCommonHandler;
+import cpw.mods.fml.common.network.simpleimpl.IMessage;
+import cpw.mods.fml.common.network.simpleimpl.IMessageHandler;
+import cpw.mods.fml.common.network.simpleimpl.MessageContext;
+import io.netty.buffer.ByteBuf;
+import net.minecraft.entity.player.EntityPlayerMP;
+
+/**
+ * LootGames 扫雷预览请求包。
+ */
+public class PacketLootGamesMinesweeperPreviewRequest implements IMessage {
+
+    public int requestId;
+    public int targetX;
+    public int targetY;
+    public int targetZ;
+    public int radius;
+    public int maxTargets;
+
+    public PacketLootGamesMinesweeperPreviewRequest() {}
+
+    public PacketLootGamesMinesweeperPreviewRequest(int requestId, ChainTarget target, int radius, int maxTargets) {
+        this.requestId = requestId;
+        this.targetX = target.getX();
+        this.targetY = target.getY();
+        this.targetZ = target.getZ();
+        this.radius = radius;
+        this.maxTargets = maxTargets;
+    }
+
+    @Override
+    public void fromBytes(ByteBuf buf) {
+        requestId = buf.readInt();
+        targetX = buf.readInt();
+        targetY = buf.readInt();
+        targetZ = buf.readInt();
+        radius = buf.readInt();
+        maxTargets = buf.readInt();
+    }
+
+    @Override
+    public void toBytes(ByteBuf buf) {
+        buf.writeInt(requestId);
+        buf.writeInt(targetX);
+        buf.writeInt(targetY);
+        buf.writeInt(targetZ);
+        buf.writeInt(radius);
+        buf.writeInt(maxTargets);
+    }
+
+    /**
+     * 服务端处理扫雷预览请求。
+     */
+    public static class Handler implements IMessageHandler<PacketLootGamesMinesweeperPreviewRequest, IMessage> {
+
+        @Override
+        public IMessage onMessage(final PacketLootGamesMinesweeperPreviewRequest message, final MessageContext ctx) {
+            if (MyMod.networkMain == null) {
+                return null;
+            }
+
+            EntityPlayerMP player = ctx.getServerHandler().playerEntity;
+            ChainTarget target = new ChainTarget(message.targetX, message.targetY, message.targetZ);
+            List<ChainTarget> bombs = LootGamesMinesweeperHelper.collectBombTargets(
+                player.worldObj,
+                target,
+                Math.max(1, message.radius),
+                Math.max(1, message.maxTargets));
+            MyMod.networkMain.network.sendTo(new PacketLootGamesMinesweeperPreviewResponse(message.requestId, target, bombs), player);
+            return null;
+        }
+    }
+}

--- a/src/main/java/club/heiqi/qz_miner/network/PacketLootGamesMinesweeperPreviewResponse.java
+++ b/src/main/java/club/heiqi/qz_miner/network/PacketLootGamesMinesweeperPreviewResponse.java
@@ -1,0 +1,88 @@
+package club.heiqi.qz_miner.network;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import club.heiqi.qz_miner.ClientProxy;
+import club.heiqi.qz_miner.chain.planner.ChainTarget;
+import cpw.mods.fml.common.network.simpleimpl.IMessage;
+import cpw.mods.fml.common.network.simpleimpl.IMessageHandler;
+import cpw.mods.fml.common.network.simpleimpl.MessageContext;
+import cpw.mods.fml.client.FMLClientHandler;
+import io.netty.buffer.ByteBuf;
+
+/**
+ * LootGames 扫雷预览结果响应包。
+ */
+public class PacketLootGamesMinesweeperPreviewResponse implements IMessage {
+
+    public int requestId;
+    public int originX;
+    public int originY;
+    public int originZ;
+    public final List<ChainTarget> targets = new ArrayList<ChainTarget>();
+
+    public PacketLootGamesMinesweeperPreviewResponse() {}
+
+    public PacketLootGamesMinesweeperPreviewResponse(int requestId, ChainTarget origin, List<ChainTarget> targets) {
+        this.requestId = requestId;
+        this.originX = origin.getX();
+        this.originY = origin.getY();
+        this.originZ = origin.getZ();
+        if (targets != null) {
+            this.targets.addAll(targets);
+        }
+    }
+
+    @Override
+    public void fromBytes(ByteBuf buf) {
+        requestId = buf.readInt();
+        originX = buf.readInt();
+        originY = buf.readInt();
+        originZ = buf.readInt();
+        targets.clear();
+        int size = buf.readInt();
+        for (int i = 0; i < size; i++) {
+            targets.add(new ChainTarget(buf.readInt(), buf.readInt(), buf.readInt()));
+        }
+    }
+
+    @Override
+    public void toBytes(ByteBuf buf) {
+        buf.writeInt(requestId);
+        buf.writeInt(originX);
+        buf.writeInt(originY);
+        buf.writeInt(originZ);
+        buf.writeInt(targets.size());
+        for (ChainTarget target : targets) {
+            buf.writeInt(target.getX());
+            buf.writeInt(target.getY());
+            buf.writeInt(target.getZ());
+        }
+    }
+
+    /**
+     * 客户端应用扫雷预览结果。
+     */
+    public static class Handler implements IMessageHandler<PacketLootGamesMinesweeperPreviewResponse, IMessage> {
+
+        @Override
+        public IMessage onMessage(final PacketLootGamesMinesweeperPreviewResponse message, MessageContext ctx) {
+            FMLClientHandler.instance().getClient().func_152344_a(new Runnable() {
+
+                @Override
+                public void run() {
+                    if (ClientProxy.chainPreviewController == null) {
+                        return;
+                    }
+
+                    ClientProxy.chainPreviewController.applyLootGamesMinesweeperPreview(
+                        message.requestId,
+                        new ChainTarget(message.originX, message.originY, message.originZ),
+                        message.targets);
+                }
+            });
+            return null;
+        }
+    }
+}

--- a/src/main/resources/assets/qz_miner/lang/en_US.lang
+++ b/src/main/resources/assets/qz_miner/lang/en_US.lang
@@ -21,6 +21,7 @@ hud.qz_miner.sub_mode.area.ore=Blasting Ore Mode
 hud.qz_miner.sub_mode.area.tunnel=Tunnel Blasting Mode
 hud.qz_miner.sub_mode.interact.base=Chain Block Interaction Mode
 hud.qz_miner.sub_mode.interact.crop=Crop Interaction Mode
+hud.qz_miner.sub_mode.special.lootgames_minesweeper=Special Minesweeper Preview Mode
 hud.qz_miner.sub_mode.special.base=Special Base Mode
 hud.qz_miner.sub_mode.special.extended=Special Extended Mode
 key.categories.qz_miner=Qz-Miner

--- a/src/main/resources/assets/qz_miner/lang/zh_CN.lang
+++ b/src/main/resources/assets/qz_miner/lang/zh_CN.lang
@@ -21,6 +21,7 @@ hud.qz_miner.sub_mode.area.ore=爆破矿石模式
 hud.qz_miner.sub_mode.area.tunnel=爆破隧道模式
 hud.qz_miner.sub_mode.interact.base=连锁块交互模式
 hud.qz_miner.sub_mode.interact.crop=作物交互模式
+hud.qz_miner.sub_mode.special.lootgames_minesweeper=特殊扫雷预览模式
 hud.qz_miner.sub_mode.special.base=特殊基础模式
 hud.qz_miner.sub_mode.special.extended=特殊扩展模式
 key.categories.qz_miner=Qz-Miner


### PR DESCRIPTION
- 新增 SPECIAL 的 LootGames 扫雷预览子模式，客户端对准扫雷棋盘时通过服务端查询返回雷点并复用现有预览器渲染
- 添加 LootGames 依赖、专用兼容读取工具与请求/响应网络包，补齐中英文 HUD 子模式文案
- 将 GT、BartWorks、GT++ 的时运破限注入从 @ModifyArg 调整为更稳的 @Redirect，修复 TileEntityOres 变换失败导致的启动崩溃