### PR TITLE
[Fix]: 修复连锁挖掘结束后掉落被提前清空

### DIFF
--- a/src/main/java/club/heiqi/qz_miner/chain/executor/ChainDropCollector.java
+++ b/src/main/java/club/heiqi/qz_miner/chain/executor/ChainDropCollector.java
@@ -81,6 +81,7 @@ public class ChainDropCollector {
                 && session.getRuntimeState().getPendingBreakTargets().isEmpty()
                 && !session.getRuntimeState().isPlannerRunning()) {
                 playerState.clearSession();
+                MyMod.chainStateService.syncPlayerState(playerState.getPlayerUUID());
             }
         }
     }

--- a/src/main/java/club/heiqi/qz_miner/chain/state/ChainPlayerState.java
+++ b/src/main/java/club/heiqi/qz_miner/chain/state/ChainPlayerState.java
@@ -142,4 +142,23 @@ public class ChainPlayerState {
         }
         MyMod.LOG.debug("[ChainState] Cleared runtime state for player {}, reason={}", playerUUID, reason);
     }
+
+    /**
+     * 停止当前连锁，但保留待释放掉落直到掉落实体生成结束。
+     *
+     * @param reason 停止原因
+     */
+    public void stopExecutionPreservingDrops(String reason) {
+        setExecutionStatus(ChainExecutionStatus.IDLE, reason);
+        if (session == null) {
+            return;
+        }
+
+        session.getRuntimeState().stopExecutionPreservingDrops(reason);
+        if (session.getRuntimeState().getPendingDrops().isEmpty()) {
+            clearSession();
+        }
+        MyMod.LOG.debug("[ChainState] Stopped execution for player {}, reason={}, pendingDrops={}",
+            playerUUID, reason, session == null ? 0 : session.getRuntimeState().getPendingDrops().size());
+    }
 }

--- a/src/main/java/club/heiqi/qz_miner/chain/state/ChainRuntimeState.java
+++ b/src/main/java/club/heiqi/qz_miner/chain/state/ChainRuntimeState.java
@@ -145,4 +145,31 @@ public final class ChainRuntimeState {
         MyMod.LOG.debug("[ChainRuntime] Cleared runtime state for player {}, reason={}, queuedTargets={}",
             playerUUID, reason, queuedTargets);
     }
+
+    /**
+     * 停止本次连锁执行，但保留待释放掉落。
+     *
+     * @param reason 停止原因
+     */
+    public void stopExecutionPreservingDrops(String reason) {
+        int queuedTargets = pendingBreakTargets.size();
+        int pendingDropCount = pendingDrops.size();
+        if (plannerSubscription != null) {
+            plannerSubscription.unregister();
+            setPlannerSubscription(null);
+        }
+        if (executorSubscription != null) {
+            executorSubscription.unregister();
+            setExecutorSubscription(null);
+        }
+        traversalTargets.clear();
+        pendingBreakTargets.clear();
+        plannerRunning = false;
+        plannerCompleted = false;
+        plannerHeartbeatMillis = 0L;
+        matchedTargetCount = 0;
+        resetExecutorThrottle();
+        MyMod.LOG.debug("[ChainRuntime] Stopped execution for player {}, reason={}, queuedTargets={}, pendingDrops={}",
+            playerUUID, reason, queuedTargets, pendingDropCount);
+    }
 }

--- a/src/main/java/club/heiqi/qz_miner/chain/state/ChainStateService.java
+++ b/src/main/java/club/heiqi/qz_miner/chain/state/ChainStateService.java
@@ -179,7 +179,7 @@ public final class ChainStateService {
             state.getExecutionStatus(),
             queuedTargets,
             pendingDrops);
-        state.clearRuntimeState(reason);
+        state.stopExecutionPreservingDrops(reason);
         syncPlayerState(playerUUID);
     }
 


### PR DESCRIPTION
- 将停止执行与最终清理会话拆分，连锁结束时保留待释放掉落，避免方块已破坏但聚合掉落尚未生成就被清空
- 在掉落聚合器真正释放掉落后再清理会话，并补发一次状态同步，保证客户端与服务端状态一致
- 保持原有掉落聚合流程不变，仅修正会话生命周期与清理时机