### PR TITLE
[Add]: 支持客户端建议连锁参数并显示服务端上限

### DIFF
--- a/src/main/java/club/heiqi/qz_miner/ClientProxy.java
+++ b/src/main/java/club/heiqi/qz_miner/ClientProxy.java
@@ -5,6 +5,7 @@ import club.heiqi.qz_miner.chain.client.ChainPreviewRenderer;
 import club.heiqi.qz_miner.chain.mode.ChainMode;
 import club.heiqi.qz_miner.chain.mode.ChainSubMode;
 import club.heiqi.qz_miner.chain.state.ChainExecutionStatus;
+import club.heiqi.qz_miner.client.ClientConnectionListener;
 import club.heiqi.qz_miner.client.HudOverlay;
 import club.heiqi.qz_miner.client.KeyListener;
 import cpw.mods.fml.common.event.FMLInitializationEvent;
@@ -21,6 +22,7 @@ public class ClientProxy extends CommonProxy {
         chainPreviewController.register();
         chainPreviewRenderer = new ChainPreviewRenderer();
         chainPreviewRenderer.register();
+        new ClientConnectionListener().register();
         HudOverlay hudOverlay = new HudOverlay();
         hudOverlay.register();
         new KeyListener(hudOverlay).register();

--- a/src/main/java/club/heiqi/qz_miner/Config.java
+++ b/src/main/java/club/heiqi/qz_miner/Config.java
@@ -2,9 +2,13 @@ package club.heiqi.qz_miner;
 
 import java.io.File;
 
+import cpw.mods.fml.client.FMLClientHandler;
 import cpw.mods.fml.client.event.ConfigChangedEvent;
 import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+import club.heiqi.qz_miner.network.PacketChainConfigRequest;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.config.Configuration;
 
@@ -87,5 +91,20 @@ public class Config {
         }
 
         load();
+        syncClientRequestedChainConfig();
+    }
+
+    @SideOnly(Side.CLIENT)
+    private void syncClientRequestedChainConfig() {
+        if (MyMod.chainStateService == null) {
+            return;
+        }
+
+        MyMod.chainStateService.setClientRequestedChainConfig(chainRadius, chainMaxBlocks);
+        if (MyMod.networkMain == null || FMLClientHandler.instance().getClient().isSingleplayer()) {
+            return;
+        }
+
+        MyMod.networkMain.network.sendToServer(new PacketChainConfigRequest(chainRadius, chainMaxBlocks));
     }
 }

--- a/src/main/java/club/heiqi/qz_miner/chain/planner/BlockBoxScanPlanningStrategy.java
+++ b/src/main/java/club/heiqi/qz_miner/chain/planner/BlockBoxScanPlanningStrategy.java
@@ -58,7 +58,12 @@ public class BlockBoxScanPlanningStrategy implements ChainPlanningStrategy {
             playerState.getSelectedMode(),
             playerState.getSelectedSubMode(),
             origin,
-            AxisAlignedTunnelDirection.resolveFace(player));
+            AxisAlignedTunnelDirection.resolveFace(player),
+            0.0F,
+            0.0F,
+            0.0F,
+            playerState.getRequestedChainRadius(),
+            playerState.getRequestedChainMaxBlocks());
         playerState.setSession(session);
         playerState.setExecutionStatus(ChainExecutionStatus.PLANNING, "start-area-plan");
         session.getRuntimeState().setPlannerRunning(true);

--- a/src/main/java/club/heiqi/qz_miner/chain/planner/BlockFloodFillPlanningStrategy.java
+++ b/src/main/java/club/heiqi/qz_miner/chain/planner/BlockFloodFillPlanningStrategy.java
@@ -24,7 +24,13 @@ public class BlockFloodFillPlanningStrategy extends AbstractFloodFillPlanningStr
             player.getUniqueID(),
             playerState.getSelectedMode(),
             playerState.getSelectedSubMode(),
-            origin);
+            origin,
+            1,
+            0.0F,
+            0.0F,
+            0.0F,
+            playerState.getRequestedChainRadius(),
+            playerState.getRequestedChainMaxBlocks());
         startPlanningInternal(player, playerState, origin, session);
     }
 

--- a/src/main/java/club/heiqi/qz_miner/chain/planner/ChainPlanningRuntimeFactory.java
+++ b/src/main/java/club/heiqi/qz_miner/chain/planner/ChainPlanningRuntimeFactory.java
@@ -35,12 +35,16 @@ public final class ChainPlanningRuntimeFactory {
         }
 
         session.getRuntimeState().getTraversalTargets().clear();
+        int requestedRadius = session.getRequest().getRequestedChainRadius();
+        int requestedMaxBlocks = session.getRequest().getRequestedChainMaxBlocks();
+        int effectiveRadius = requestedRadius > 0 ? Math.min(Config.chainRadius, requestedRadius) : Config.chainRadius;
+        int effectiveMaxBlocks = requestedMaxBlocks > 0 ? Math.min(Config.chainMaxBlocks, requestedMaxBlocks) : Config.chainMaxBlocks;
         ChainSearchContext searchContext = createSearchContext(
             world,
             seedSnapshot,
             session.getRequest().getSubMode(),
-            Config.chainRadius,
-            Config.chainMaxBlocks,
+            effectiveRadius,
+            effectiveMaxBlocks,
             session.getRuntimeState().getTraversalTargets());
 
         return createRuntime(player, session, searchContext, session.getRequest().getMode());

--- a/src/main/java/club/heiqi/qz_miner/chain/planner/InteractFloodFillPlanningStrategy.java
+++ b/src/main/java/club/heiqi/qz_miner/chain/planner/InteractFloodFillPlanningStrategy.java
@@ -55,7 +55,9 @@ public class InteractFloodFillPlanningStrategy extends AbstractFloodFillPlanning
             interactFace,
             interactHitX,
             interactHitY,
-            interactHitZ);
+            interactHitZ,
+            playerState.getRequestedChainRadius(),
+            playerState.getRequestedChainMaxBlocks());
         startPlanningInternal(player, playerState, origin, session);
     }
 

--- a/src/main/java/club/heiqi/qz_miner/chain/state/ChainClientState.java
+++ b/src/main/java/club/heiqi/qz_miner/chain/state/ChainClientState.java
@@ -21,6 +21,8 @@ public class ChainClientState {
     private volatile ChainMode selectedMode = ChainModeRegistry.getDefaultMode();
     private volatile ChainSubMode selectedSubMode = ChainModeRegistry.getDefaultSubMode(ChainModeRegistry.getDefaultMode());
     private final Map<ChainMode, ChainSubMode> rememberedSubModes = new EnumMap<ChainMode, ChainSubMode>(ChainMode.class);
+    private volatile int requestedChainRadius = Config.chainRadius;
+    private volatile int requestedChainMaxBlocks = Config.chainMaxBlocks;
     private volatile int serverChainRadius = Config.chainRadius;
     private volatile int serverChainMaxBlocks = Config.chainMaxBlocks;
     private volatile int serverMatchedTargetCount;
@@ -101,12 +103,28 @@ public class ChainClientState {
         return serverChainRadius;
     }
 
+    public int getRequestedChainRadius() {
+        return requestedChainRadius;
+    }
+
+    public void setRequestedChainRadius(int requestedChainRadius) {
+        this.requestedChainRadius = Math.max(1, requestedChainRadius);
+    }
+
     public void setServerChainRadius(int serverChainRadius) {
         this.serverChainRadius = Math.max(1, serverChainRadius);
     }
 
     public int getServerChainMaxBlocks() {
         return serverChainMaxBlocks;
+    }
+
+    public int getRequestedChainMaxBlocks() {
+        return requestedChainMaxBlocks;
+    }
+
+    public void setRequestedChainMaxBlocks(int requestedChainMaxBlocks) {
+        this.requestedChainMaxBlocks = Math.max(1, requestedChainMaxBlocks);
     }
 
     public void setServerChainMaxBlocks(int serverChainMaxBlocks) {

--- a/src/main/java/club/heiqi/qz_miner/chain/state/ChainPlayerState.java
+++ b/src/main/java/club/heiqi/qz_miner/chain/state/ChainPlayerState.java
@@ -20,6 +20,8 @@ public class ChainPlayerState {
     private ChainMode selectedMode = ChainModeRegistry.getDefaultMode();
     private ChainSubMode selectedSubMode = ChainModeRegistry.getDefaultSubMode(ChainModeRegistry.getDefaultMode());
     private final Map<ChainMode, ChainSubMode> rememberedSubModes = new EnumMap<ChainMode, ChainSubMode>(ChainMode.class);
+    private volatile int requestedChainRadius = -1;
+    private volatile int requestedChainMaxBlocks = -1;
     private volatile ChainSession session;
 
     public ChainPlayerState(UUID playerUUID) {
@@ -125,6 +127,22 @@ public class ChainPlayerState {
 
     public ChainSession getSession() {
         return session;
+    }
+
+    public int getRequestedChainRadius() {
+        return requestedChainRadius;
+    }
+
+    public void setRequestedChainRadius(int requestedChainRadius) {
+        this.requestedChainRadius = requestedChainRadius;
+    }
+
+    public int getRequestedChainMaxBlocks() {
+        return requestedChainMaxBlocks;
+    }
+
+    public void setRequestedChainMaxBlocks(int requestedChainMaxBlocks) {
+        this.requestedChainMaxBlocks = requestedChainMaxBlocks;
     }
 
     public void setSession(ChainSession session) {

--- a/src/main/java/club/heiqi/qz_miner/chain/state/ChainRequest.java
+++ b/src/main/java/club/heiqi/qz_miner/chain/state/ChainRequest.java
@@ -20,16 +20,22 @@ public final class ChainRequest {
     private final float interactHitX;
     private final float interactHitY;
     private final float interactHitZ;
+    private final int requestedChainRadius;
+    private final int requestedChainMaxBlocks;
 
     public ChainRequest(UUID playerUUID, ChainMode mode, ChainSubMode subMode, ChainTarget origin) {
-        this(playerUUID, mode, subMode, origin, 1, 0.0F, 0.0F, 0.0F);
+        this(playerUUID, mode, subMode, origin, 1, 0.0F, 0.0F, 0.0F, -1, -1);
     }
 
     public ChainRequest(UUID playerUUID, ChainMode mode, ChainSubMode subMode, ChainTarget origin, int interactFace) {
-        this(playerUUID, mode, subMode, origin, interactFace, 0.0F, 0.0F, 0.0F);
+        this(playerUUID, mode, subMode, origin, interactFace, 0.0F, 0.0F, 0.0F, -1, -1);
     }
 
     public ChainRequest(UUID playerUUID, ChainMode mode, ChainSubMode subMode, ChainTarget origin, int interactFace, float interactHitX, float interactHitY, float interactHitZ) {
+        this(playerUUID, mode, subMode, origin, interactFace, interactHitX, interactHitY, interactHitZ, -1, -1);
+    }
+
+    public ChainRequest(UUID playerUUID, ChainMode mode, ChainSubMode subMode, ChainTarget origin, int interactFace, float interactHitX, float interactHitY, float interactHitZ, int requestedChainRadius, int requestedChainMaxBlocks) {
         this.playerUUID = playerUUID;
         this.mode = mode;
         this.subMode = ChainModeRegistry.resolveSubMode(mode, subMode);
@@ -38,6 +44,8 @@ public final class ChainRequest {
         this.interactHitX = interactHitX;
         this.interactHitY = interactHitY;
         this.interactHitZ = interactHitZ;
+        this.requestedChainRadius = requestedChainRadius;
+        this.requestedChainMaxBlocks = requestedChainMaxBlocks;
     }
 
     public UUID getPlayerUUID() {
@@ -70,5 +78,13 @@ public final class ChainRequest {
 
     public float getInteractHitZ() {
         return interactHitZ;
+    }
+
+    public int getRequestedChainRadius() {
+        return requestedChainRadius;
+    }
+
+    public int getRequestedChainMaxBlocks() {
+        return requestedChainMaxBlocks;
     }
 }

--- a/src/main/java/club/heiqi/qz_miner/chain/state/ChainSession.java
+++ b/src/main/java/club/heiqi/qz_miner/chain/state/ChainSession.java
@@ -14,7 +14,7 @@ public class ChainSession {
     private final ChainRuntimeState runtimeState;
 
     public ChainSession(UUID playerUUID, ChainMode mode, ChainSubMode subMode, ChainTarget origin) {
-        this(playerUUID, mode, subMode, origin, 1, 0.0F, 0.0F, 0.0F);
+        this(playerUUID, mode, subMode, origin, 1, 0.0F, 0.0F, 0.0F, -1, -1);
     }
 
     /**
@@ -27,7 +27,7 @@ public class ChainSession {
      * @param interactFace 交互点击面
      */
     public ChainSession(UUID playerUUID, ChainMode mode, ChainSubMode subMode, ChainTarget origin, int interactFace) {
-        this(playerUUID, mode, subMode, origin, interactFace, 0.0F, 0.0F, 0.0F);
+        this(playerUUID, mode, subMode, origin, interactFace, 0.0F, 0.0F, 0.0F, -1, -1);
     }
 
     /**
@@ -43,7 +43,11 @@ public class ChainSession {
      * @param interactHitZ 命中点 Z 偏移
      */
     public ChainSession(UUID playerUUID, ChainMode mode, ChainSubMode subMode, ChainTarget origin, int interactFace, float interactHitX, float interactHitY, float interactHitZ) {
-        this(new ChainRequest(playerUUID, mode, subMode, origin, interactFace, interactHitX, interactHitY, interactHitZ));
+        this(playerUUID, mode, subMode, origin, interactFace, interactHitX, interactHitY, interactHitZ, -1, -1);
+    }
+
+    public ChainSession(UUID playerUUID, ChainMode mode, ChainSubMode subMode, ChainTarget origin, int interactFace, float interactHitX, float interactHitY, float interactHitZ, int requestedChainRadius, int requestedChainMaxBlocks) {
+        this(new ChainRequest(playerUUID, mode, subMode, origin, interactFace, interactHitX, interactHitY, interactHitZ, requestedChainRadius, requestedChainMaxBlocks));
     }
 
     public ChainSession(ChainRequest request) {

--- a/src/main/java/club/heiqi/qz_miner/chain/state/ChainStateService.java
+++ b/src/main/java/club/heiqi/qz_miner/chain/state/ChainStateService.java
@@ -118,6 +118,13 @@ public final class ChainStateService {
         MyMod.LOG.debug("[ChainState] Client chain key pressed={}", pressed);
     }
 
+    public void setClientRequestedChainConfig(int requestedChainRadius, int requestedChainMaxBlocks) {
+        clientState.setRequestedChainRadius(requestedChainRadius);
+        clientState.setRequestedChainMaxBlocks(requestedChainMaxBlocks);
+        MyMod.LOG.debug("[ChainState] Client requested chain config radius={} maxBlocks={}",
+            clientState.getRequestedChainRadius(), clientState.getRequestedChainMaxBlocks());
+    }
+
     public void syncPlayerState(UUID playerUUID) {
         if (MyMod.networkMain == null || MyMod.playerManager == null) {
             return;

--- a/src/main/java/club/heiqi/qz_miner/client/ClientConnectionListener.java
+++ b/src/main/java/club/heiqi/qz_miner/client/ClientConnectionListener.java
@@ -1,0 +1,35 @@
+package club.heiqi.qz_miner.client;
+
+import club.heiqi.qz_miner.Config;
+import club.heiqi.qz_miner.MyMod;
+import club.heiqi.qz_miner.network.PacketChainConfigRequest;
+import cpw.mods.fml.client.FMLClientHandler;
+import cpw.mods.fml.common.eventhandler.SubscribeEvent;
+import cpw.mods.fml.common.network.FMLNetworkEvent;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+
+/**
+ * 客户端连接事件监听。
+ */
+@SideOnly(Side.CLIENT)
+public class ClientConnectionListener {
+
+    public void register() {
+        cpw.mods.fml.common.FMLCommonHandler.instance().bus().register(this);
+    }
+
+    @SubscribeEvent
+    public void onClientConnected(FMLNetworkEvent.ClientConnectedToServerEvent event) {
+        if (MyMod.chainStateService == null) {
+            return;
+        }
+
+        MyMod.chainStateService.setClientRequestedChainConfig(Config.chainRadius, Config.chainMaxBlocks);
+        if (MyMod.networkMain == null || FMLClientHandler.instance().getClient().isSingleplayer()) {
+            return;
+        }
+
+        MyMod.networkMain.network.sendToServer(new PacketChainConfigRequest(Config.chainRadius, Config.chainMaxBlocks));
+    }
+}

--- a/src/main/java/club/heiqi/qz_miner/client/HudOverlay.java
+++ b/src/main/java/club/heiqi/qz_miner/client/HudOverlay.java
@@ -72,16 +72,26 @@ public class HudOverlay {
         String modeText = "\u00a77" + ClientI18n.tr("hud.qz_miner.current_mode", ClientI18n.tr(selectedMode.getDisplayNameKey()));
         mc.fontRenderer.drawStringWithShadow(modeText, x, y - 10, 0xFFFFFF);
 
-        int serverMatchedY = y - 20;
-        int previewMatchedY = y - 30;
-        int areaInfoY = y - 30;
+        int configInfoY = y - 20;
+        int serverMatchedY = y - 30;
+        int previewMatchedY = y - 40;
+        int areaInfoY = y - 40;
         if (selectedSubMode != null) {
             String subModeText = "\u00a77" + ClientI18n.tr("hud.qz_miner.current_sub_mode", ClientI18n.tr(selectedSubMode.getDisplayNameKey()));
             mc.fontRenderer.drawStringWithShadow(subModeText, x, y - 20, 0xFFFFFF);
-            serverMatchedY = y - 30;
-            previewMatchedY = y - 40;
-            areaInfoY = y - 40;
+            configInfoY = y - 30;
+            serverMatchedY = y - 40;
+            previewMatchedY = y - 50;
+            areaInfoY = y - 50;
         }
+
+        String chainConfigText = "\u00a77" + ClientI18n.tr(
+            "hud.qz_miner.chain_config",
+            MyMod.chainStateService.getClientState().getRequestedChainRadius(),
+            MyMod.chainStateService.getClientState().getServerChainRadius(),
+            MyMod.chainStateService.getClientState().getRequestedChainMaxBlocks(),
+            MyMod.chainStateService.getClientState().getServerChainMaxBlocks());
+        mc.fontRenderer.drawStringWithShadow(chainConfigText, x, configInfoY, 0xFFFFFF);
 
         String serverMatchedText = "\u00a77" + ClientI18n.tr(
             "hud.qz_miner.server_matched",
@@ -108,7 +118,7 @@ public class HudOverlay {
                     areaDimensions[1],
                     areaDimensions[2],
                     areaBlockCount);
-                mc.fontRenderer.drawStringWithShadow(areaText, x, y - 50, 0xFFFFFF);
+                mc.fontRenderer.drawStringWithShadow(areaText, x, y - 60, 0xFFFFFF);
             }
         } else if (showAreaInfo) {
             int[] areaDimensions = resolveAreaDimensions(modeDefinition, selectedSubMode);

--- a/src/main/java/club/heiqi/qz_miner/client/KeyListener.java
+++ b/src/main/java/club/heiqi/qz_miner/client/KeyListener.java
@@ -1,11 +1,13 @@
 package club.heiqi.qz_miner.client;
 
+import club.heiqi.qz_miner.Config;
 import club.heiqi.qz_miner.MyMod;
 import club.heiqi.qz_miner.chain.ChainConstants;
 import club.heiqi.qz_miner.chain.mode.ChainMode;
 import club.heiqi.qz_miner.chain.mode.ChainModeRegistry;
 import club.heiqi.qz_miner.chain.mode.ChainSubMode;
 import club.heiqi.qz_miner.network.PacketChainSubModeSwitch;
+import club.heiqi.qz_miner.network.PacketChainConfigRequest;
 import club.heiqi.qz_miner.network.PacketKeyState;
 import club.heiqi.qz_miner.network.PacketChainModeSwitch;
 import cpw.mods.fml.client.FMLClientHandler;
@@ -148,8 +150,26 @@ public class KeyListener {
             MyMod.chainStateService.setClientChainKeyPressed(pressed);
         }
         if (MyMod.networkMain != null) {
+            if (pressed) {
+                syncRequestedChainConfigToServer();
+            }
             MyMod.networkMain.network.sendToServer(new PacketKeyState(KEY_CHAIN, pressed));
         }
         hudOverlay.setChainActive(pressed);
+    }
+
+    private void syncRequestedChainConfigToServer() {
+        if (MyMod.chainStateService == null || MyMod.networkMain == null) {
+            return;
+        }
+
+        if (FMLClientHandler.instance().getClient().isSingleplayer()) {
+            return;
+        }
+
+        MyMod.chainStateService.setClientRequestedChainConfig(Config.chainRadius, Config.chainMaxBlocks);
+        MyMod.networkMain.network.sendToServer(new PacketChainConfigRequest(
+            MyMod.chainStateService.getClientState().getRequestedChainRadius(),
+            MyMod.chainStateService.getClientState().getRequestedChainMaxBlocks()));
     }
 }

--- a/src/main/java/club/heiqi/qz_miner/network/NetworkMain.java
+++ b/src/main/java/club/heiqi/qz_miner/network/NetworkMain.java
@@ -46,6 +46,11 @@ public final class NetworkMain {
                 packetId++,
                 Side.CLIENT);
         network.registerMessage(
+                PacketChainConfigRequest.Handler.class,
+                PacketChainConfigRequest.class,
+                packetId++,
+                Side.SERVER);
+        network.registerMessage(
                 PacketLootGamesMinesweeperPreviewRequest.Handler.class,
                 PacketLootGamesMinesweeperPreviewRequest.class,
                 packetId++,

--- a/src/main/java/club/heiqi/qz_miner/network/PacketChainConfigRequest.java
+++ b/src/main/java/club/heiqi/qz_miner/network/PacketChainConfigRequest.java
@@ -1,0 +1,58 @@
+package club.heiqi.qz_miner.network;
+
+import club.heiqi.qz_miner.MyMod;
+import club.heiqi.qz_miner.chain.state.ChainPlayerState;
+import cpw.mods.fml.common.network.simpleimpl.IMessage;
+import cpw.mods.fml.common.network.simpleimpl.IMessageHandler;
+import cpw.mods.fml.common.network.simpleimpl.MessageContext;
+import io.netty.buffer.ByteBuf;
+import net.minecraft.entity.player.EntityPlayerMP;
+
+/**
+ * 客户端向服务端提交建议连锁参数。
+ */
+public class PacketChainConfigRequest implements IMessage {
+
+    public int requestedChainRadius;
+    public int requestedChainMaxBlocks;
+
+    public PacketChainConfigRequest() {}
+
+    public PacketChainConfigRequest(int requestedChainRadius, int requestedChainMaxBlocks) {
+        this.requestedChainRadius = requestedChainRadius;
+        this.requestedChainMaxBlocks = requestedChainMaxBlocks;
+    }
+
+    @Override
+    public void fromBytes(ByteBuf buf) {
+        requestedChainRadius = buf.readInt();
+        requestedChainMaxBlocks = buf.readInt();
+    }
+
+    @Override
+    public void toBytes(ByteBuf buf) {
+        buf.writeInt(requestedChainRadius);
+        buf.writeInt(requestedChainMaxBlocks);
+    }
+
+    /**
+     * 服务端记录客户端建议参数。
+     */
+    public static class Handler implements IMessageHandler<PacketChainConfigRequest, IMessage> {
+
+        @Override
+        public IMessage onMessage(PacketChainConfigRequest message, MessageContext ctx) {
+            if (MyMod.chainStateService == null) {
+                return null;
+            }
+
+            EntityPlayerMP player = ctx.getServerHandler().playerEntity;
+            ChainPlayerState state = MyMod.chainStateService.getOrCreatePlayerState(player.getUniqueID());
+            state.setRequestedChainRadius(message.requestedChainRadius > 0 ? message.requestedChainRadius : -1);
+            state.setRequestedChainMaxBlocks(message.requestedChainMaxBlocks > 0 ? message.requestedChainMaxBlocks : -1);
+            MyMod.LOG.debug("[ChainConfig] Received client request config for player {} radius={} maxBlocks={}",
+                player.getUniqueID(), state.getRequestedChainRadius(), state.getRequestedChainMaxBlocks());
+            return null;
+        }
+    }
+}

--- a/src/main/resources/assets/qz_miner/lang/en_US.lang
+++ b/src/main/resources/assets/qz_miner/lang/en_US.lang
@@ -3,6 +3,7 @@ hud.qz_miner.status.planning=Chain Plan In Progress
 hud.qz_miner.status.idle=Chain Ready
 hud.qz_miner.current_mode=Current Mode: %s
 hud.qz_miner.current_sub_mode=Current Sub Mode: %s
+hud.qz_miner.chain_config=Requested/Limit Radius: %d/%d, Requested/Limit Blocks: %d/%d
 hud.qz_miner.server_matched=Server Matched: %d blocks
 hud.qz_miner.preview_matched=Preview Matched: %d blocks
 hud.qz_miner.preview.completed=(Completed)

--- a/src/main/resources/assets/qz_miner/lang/zh_CN.lang
+++ b/src/main/resources/assets/qz_miner/lang/zh_CN.lang
@@ -3,6 +3,7 @@ hud.qz_miner.status.planning=连锁规划中
 hud.qz_miner.status.idle=连锁待命
 hud.qz_miner.current_mode=当前模式: %s
 hud.qz_miner.current_sub_mode=当前子模式: %s
+hud.qz_miner.chain_config=请求范围/上限: %d/%d, 请求数量/上限: %d/%d
 hud.qz_miner.server_matched=服务端已匹配: %d 个方块
 hud.qz_miner.preview_matched=预览已匹配: %d 个方块
 hud.qz_miner.preview.completed=(完成)


### PR DESCRIPTION
- 新增客户端到服务端的连锁半径与最大数量建议参数同步，仅在远程服务器场景下发送，服务端启动连锁时按客户端建议值与服务端配置上限取较小值
- 将建议参数写入玩家状态与会话请求快照，使 CHAIN、AREA、INTERACT 规划统一使用同一套钳制后的有效参数
- 在 HUD 中新增请求值与服务端上限值提示，方便玩家直观看到当前请求范围、数量以及服务器限制