### PR TITLE
[Add]: 新增GT线缆连锁替换特殊模式

### DIFF
--- a/src/main/java/club/heiqi/qz_miner/MyMod.java
+++ b/src/main/java/club/heiqi/qz_miner/MyMod.java
@@ -10,6 +10,7 @@ import club.heiqi.qz_miner.chain.executor.ChainExecutor;
 import club.heiqi.qz_miner.chain.mode.ChainModeBootstrap;
 import club.heiqi.qz_miner.chain.planner.ChainInteractPlanner;
 import club.heiqi.qz_miner.chain.planner.ChainPlanner;
+import club.heiqi.qz_miner.chain.planner.GregTechCableReplacePlanner;
 import club.heiqi.qz_miner.event.EventListener;
 import club.heiqi.qz_miner.event.PlayerStateEvent;
 import club.heiqi.qz_miner.event.QzEvents;
@@ -39,6 +40,7 @@ public class MyMod {
     public static ChainStateService chainStateService;
     public static ChainPlanner chainPlanner;
     public static ChainInteractPlanner chainInteractPlanner;
+    public static GregTechCableReplacePlanner gregTechCableReplacePlanner;
     public static ChainDropCollector chainDropCollector;
     public static ChainExecutor chainExecutor;
     public static NetworkMain networkMain;
@@ -79,6 +81,7 @@ public class MyMod {
         chainStateService = new ChainStateService();
         chainPlanner = new ChainPlanner();
         chainInteractPlanner = new ChainInteractPlanner();
+        gregTechCableReplacePlanner = new GregTechCableReplacePlanner();
         chainDropCollector = new ChainDropCollector();
         chainExecutor = new ChainExecutor();
         ensureParallelTickExecutor();

--- a/src/main/java/club/heiqi/qz_miner/chain/client/ChainPreviewController.java
+++ b/src/main/java/club/heiqi/qz_miner/chain/client/ChainPreviewController.java
@@ -5,6 +5,7 @@ import club.heiqi.qz_miner.MyMod;
 import club.heiqi.qz_miner.compat.lootgames.LootGamesMinesweeperHelper;
 import club.heiqi.qz_miner.chain.mode.ChainMode;
 import club.heiqi.qz_miner.chain.mode.ChainSubMode;
+import club.heiqi.qz_miner.compat.gregtech.GregTechCableCompatHelper;
 import club.heiqi.qz_miner.chain.planner.AxisAlignedTunnelDirection;
 import club.heiqi.qz_miner.chain.planner.BlockSeedSnapshot;
 import club.heiqi.qz_miner.chain.planner.ChainBlockMatcher;
@@ -121,6 +122,11 @@ public class ChainPreviewController {
         final int previewMaxTargets = getEffectivePreviewMaxTargets();
         final ChainMode selectedMode = MyMod.chainStateService.getClientState().getSelectedMode();
         final ChainSubMode selectedSubMode = MyMod.chainStateService.getClientState().getSelectedSubMode();
+        if (selectedMode == ChainMode.SPECIAL && selectedSubMode == ChainSubMode.SPECIAL_GT_CABLE_REPLACE
+            && !GregTechCableCompatHelper.isCable(sampleTileEntity)) {
+            previewState.setCompleted(true);
+            return;
+        }
         if (selectedMode == ChainMode.SPECIAL && selectedSubMode == ChainSubMode.SPECIAL_LOOTGAMES_MINESWEEPER) {
             startLootGamesMinesweeperPreview(world, target, previewRadius, previewMaxTargets);
             return;

--- a/src/main/java/club/heiqi/qz_miner/chain/executor/GregTechCableReplaceActionExecutor.java
+++ b/src/main/java/club/heiqi/qz_miner/chain/executor/GregTechCableReplaceActionExecutor.java
@@ -1,0 +1,130 @@
+package club.heiqi.qz_miner.chain.executor;
+
+import club.heiqi.qz_miner.chain.mode.ChainMode;
+import club.heiqi.qz_miner.chain.state.ChainSession;
+import club.heiqi.qz_miner.chain.planner.ChainTarget;
+import club.heiqi.qz_miner.compat.gregtech.GregTechCableCompatHelper;
+import gregtech.api.metatileentity.BaseMetaPipeEntity;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.item.ItemStack;
+import net.minecraft.tileentity.TileEntity;
+
+/**
+ * GT 线缆替换执行器。
+ */
+public class GregTechCableReplaceActionExecutor implements ChainActionExecutor {
+
+    @Override
+    public boolean supports(ChainMode mode) {
+        return mode == ChainMode.SPECIAL;
+    }
+
+    @Override
+    public boolean canExecute(EntityPlayerMP player, ChainSession session, ChainTarget target) {
+        if (player == null || target == null) {
+            return false;
+        }
+
+        TileEntity tileEntity = player.worldObj.getTileEntity(target.getX(), target.getY(), target.getZ());
+        return GregTechCableCompatHelper.getCableBase(tileEntity) != null;
+    }
+
+    @Override
+    public boolean execute(EntityPlayerMP player, ChainSession session, ChainTarget target) {
+        if (player == null || session == null || target == null) {
+            return false;
+        }
+
+        TileEntity tileEntity = player.worldObj.getTileEntity(target.getX(), target.getY(), target.getZ());
+        BaseMetaPipeEntity baseMetaPipeEntity = GregTechCableCompatHelper.getCableBase(tileEntity);
+        if (baseMetaPipeEntity == null) {
+            return false;
+        }
+
+        LockedCableSlot lockedCableSlot = findLockedCableSlot(player, session);
+        if (lockedCableSlot == null) {
+            return false;
+        }
+
+        int previousSlot = player.inventory.currentItem;
+        try {
+            if (lockedCableSlot.slotIndex < 9) {
+                player.inventory.currentItem = lockedCableSlot.slotIndex;
+            }
+            return GregTechCableCompatHelper.replaceCableKeepingConnections(
+                player,
+                baseMetaPipeEntity,
+                lockedCableSlot.stack,
+                lockedCableSlot.slotIndex);
+        } finally {
+            player.inventory.currentItem = previousSlot;
+        }
+    }
+
+    private LockedCableSlot findLockedCableSlot(EntityPlayerMP player, ChainSession session) {
+        Integer lockedMetaTileId = GregTechCableSessionState.getLockedReplacementMetaTileId(session);
+
+        if (lockedMetaTileId != null) {
+            LockedCableSlot lockedSlot = findMatchingCable(player, lockedMetaTileId.intValue(), true);
+            if (lockedSlot != null) {
+                return lockedSlot;
+            }
+            lockedSlot = findMatchingCable(player, lockedMetaTileId.intValue(), false);
+            if (lockedSlot != null) {
+                return lockedSlot;
+            }
+        }
+
+        LockedCableSlot firstCable = findFirstCable(player, true);
+        if (firstCable == null) {
+            firstCable = findFirstCable(player, false);
+        }
+        if (firstCable == null) {
+            return null;
+        }
+
+        GregTechCableSessionState.lockReplacementMetaTileId(session, firstCable.metaTileId);
+        return firstCable;
+    }
+
+    private LockedCableSlot findMatchingCable(EntityPlayerMP player, int metaTileId, boolean hotbarOnly) {
+        int start = hotbarOnly ? 8 : player.inventory.mainInventory.length - 1;
+        int endExclusive = hotbarOnly ? -1 : 8;
+        for (int i = start; i > endExclusive; i--) {
+            ItemStack stack = player.inventory.mainInventory[i];
+            if (!GregTechCableCompatHelper.isCableStack(stack)) {
+                continue;
+            }
+            if (stack.getItemDamage() == metaTileId) {
+                return new LockedCableSlot(i, stack, metaTileId);
+            }
+        }
+        return null;
+    }
+
+    private LockedCableSlot findFirstCable(EntityPlayerMP player, boolean hotbarOnly) {
+        int start = hotbarOnly ? 8 : player.inventory.mainInventory.length - 1;
+        int endExclusive = hotbarOnly ? -1 : 8;
+        for (int i = start; i > endExclusive; i--) {
+            ItemStack stack = player.inventory.mainInventory[i];
+            if (!GregTechCableCompatHelper.isCableStack(stack)) {
+                continue;
+            }
+            return new LockedCableSlot(i, stack, stack.getItemDamage());
+        }
+        return null;
+    }
+
+    private static final class LockedCableSlot {
+
+        private final int slotIndex;
+        private final ItemStack stack;
+        private final int metaTileId;
+
+        private LockedCableSlot(int slotIndex, ItemStack stack, int metaTileId) {
+            this.slotIndex = slotIndex;
+            this.stack = stack;
+            this.metaTileId = metaTileId;
+        }
+    }
+}

--- a/src/main/java/club/heiqi/qz_miner/chain/executor/GregTechCableSessionState.java
+++ b/src/main/java/club/heiqi/qz_miner/chain/executor/GregTechCableSessionState.java
@@ -1,0 +1,38 @@
+package club.heiqi.qz_miner.chain.executor;
+
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+import club.heiqi.qz_miner.chain.state.ChainSession;
+
+/**
+ * GT 线缆替换模式会话状态。
+ */
+public final class GregTechCableSessionState {
+
+    private static final Map<UUID, Integer> LOCKED_REPLACEMENT_META_TILE_IDS = new ConcurrentHashMap<UUID, Integer>();
+
+    private GregTechCableSessionState() {}
+
+    public static Integer getLockedReplacementMetaTileId(ChainSession session) {
+        UUID playerUUID = session == null ? null : session.getPlayerUUID();
+        return playerUUID == null ? null : LOCKED_REPLACEMENT_META_TILE_IDS.get(playerUUID);
+    }
+
+    public static void lockReplacementMetaTileId(ChainSession session, int metaTileId) {
+        UUID playerUUID = session == null ? null : session.getPlayerUUID();
+        if (playerUUID == null) {
+            return;
+        }
+        LOCKED_REPLACEMENT_META_TILE_IDS.put(playerUUID, metaTileId);
+    }
+
+    public static void clear(ChainSession session) {
+        UUID playerUUID = session == null ? null : session.getPlayerUUID();
+        if (playerUUID == null) {
+            return;
+        }
+        LOCKED_REPLACEMENT_META_TILE_IDS.remove(playerUUID);
+    }
+}

--- a/src/main/java/club/heiqi/qz_miner/chain/mode/ChainModeBootstrap.java
+++ b/src/main/java/club/heiqi/qz_miner/chain/mode/ChainModeBootstrap.java
@@ -4,9 +4,13 @@ import java.util.Arrays;
 import club.heiqi.qz_miner.Config;
 import club.heiqi.qz_miner.chain.executor.BlockHarvestActionExecutor;
 import club.heiqi.qz_miner.chain.executor.BlockInteractActionExecutor;
+import club.heiqi.qz_miner.chain.executor.GregTechCableReplaceActionExecutor;
 import club.heiqi.qz_miner.chain.planner.AxisAlignedTunnelDirection;
 import club.heiqi.qz_miner.chain.planner.BlockBoxScanPlanningStrategy;
 import club.heiqi.qz_miner.chain.planner.BlockFloodFillPlanningStrategy;
+import club.heiqi.qz_miner.chain.planner.GregTechCableMatcher;
+import club.heiqi.qz_miner.chain.planner.GregTechCablePlanningStrategy;
+import club.heiqi.qz_miner.chain.planner.GregTechCableTraverser;
 import club.heiqi.qz_miner.chain.planner.BoxScanTraverser;
 import club.heiqi.qz_miner.chain.planner.ChainBlockMatcherResolver;
 import club.heiqi.qz_miner.chain.planner.ChainResolverContext;
@@ -101,6 +105,24 @@ public final class ChainModeBootstrap {
     };
     
     private static final ChainBlockMatcherResolver HARVESTABLE_MATCHER = context -> new HarvestableBlockMatcher();
+    private static final ChainTraverserResolver SPECIAL_TRAVERSER = context -> {
+        if (context != null
+            && context.getSearchContext() != null
+            && context.getSearchContext().getSubMode() == ChainSubMode.SPECIAL_GT_CABLE_REPLACE) {
+            return new GregTechCableTraverser();
+        }
+        return DEFAULT_FLOOD_FILL_TRAVERSER.createTraverser(context);
+    };
+    private static final ChainBlockMatcherResolver SPECIAL_MATCHER = context -> {
+        if (context != null
+            && context.getSearchContext() != null
+            && context.getSearchContext().getSubMode() == ChainSubMode.SPECIAL_GT_CABLE_REPLACE) {
+            return new GregTechCableMatcher(context.getSearchContext() == null ? -1
+                : club.heiqi.qz_miner.compat.gregtech.GregTechCableCompatHelper.getCableMetaTileId(
+                    context.getSearchContext().getSampleTileEntity()));
+        }
+        return HARVESTABLE_MATCHER.createMatcher(context);
+    };
     private static final ChainBlockMatcherResolver INTERACT_MATCHER = context -> {
         if (context != null
             && context.getSearchContext() != null
@@ -186,13 +208,13 @@ public final class ChainModeBootstrap {
     private static ChainModeDefinition createSpecialDefinition() {
         return new ChainModeDefinition(
             ChainMode.SPECIAL,
-            null,
-            null,
-            DEFAULT_FLOOD_FILL_TRAVERSER,
-            HARVESTABLE_MATCHER,
+            new GregTechCablePlanningStrategy(),
+            new GregTechCableReplaceActionExecutor(),
+            SPECIAL_TRAVERSER,
+            SPECIAL_MATCHER,
             false,
             null,
             ChainSubMode.SPECIAL_LOOTGAMES_MINESWEEPER,
-            Arrays.asList(ChainSubMode.SPECIAL_LOOTGAMES_MINESWEEPER));
+            Arrays.asList(ChainSubMode.SPECIAL_LOOTGAMES_MINESWEEPER, ChainSubMode.SPECIAL_GT_CABLE_REPLACE));
     }
 }

--- a/src/main/java/club/heiqi/qz_miner/chain/mode/ChainSubMode.java
+++ b/src/main/java/club/heiqi/qz_miner/chain/mode/ChainSubMode.java
@@ -43,7 +43,11 @@ public enum ChainSubMode {
     /**
      * SPECIAL LootGames 扫雷预览子模式。
      */
-    SPECIAL_LOOTGAMES_MINESWEEPER(ChainMode.SPECIAL, false, false, false);
+    SPECIAL_LOOTGAMES_MINESWEEPER(ChainMode.SPECIAL, false, false, false),
+    /**
+     * SPECIAL GT 线缆替换子模式。
+     */
+    SPECIAL_GT_CABLE_REPLACE(ChainMode.SPECIAL, false, false, false);
 
     private final ChainMode parentMode;
     private final boolean sameBlockMatchRequired;
@@ -124,6 +128,8 @@ public enum ChainSubMode {
                 return "hud.qz_miner.sub_mode.interact.crop";
             case SPECIAL_LOOTGAMES_MINESWEEPER:
                 return "hud.qz_miner.sub_mode.special.lootgames_minesweeper";
+            case SPECIAL_GT_CABLE_REPLACE:
+                return "hud.qz_miner.sub_mode.special.gt_cable_replace";
             default:
                 return name();
         }

--- a/src/main/java/club/heiqi/qz_miner/chain/planner/AbstractFloodFillPlanningStrategy.java
+++ b/src/main/java/club/heiqi/qz_miner/chain/planner/AbstractFloodFillPlanningStrategy.java
@@ -67,6 +67,11 @@ public abstract class AbstractFloodFillPlanningStrategy implements ChainPlanning
         final ChainSearchContext searchContext = runtime.getSearchContext();
         final ChainTraverser traverser = runtime.getTraverser();
         final ChainBlockMatcher blockMatcher = runtime.getMatcher();
+        if (shouldIncludeOriginTarget() && blockMatcher.matches(player, origin)) {
+            queue.add(origin);
+            searchContext.incrementConfirmedCount();
+            session.getRuntimeState().setMatchedTargetCount(searchContext.getConfirmedCount());
+        }
         traverser.seed(searchContext);
 
         ParallelTickSubscription subscription = MyMod.ensureParallelTickExecutor().registerPre(
@@ -180,6 +185,13 @@ public abstract class AbstractFloodFillPlanningStrategy implements ChainPlanning
      * 返回日志中的模式标签。
      */
     protected abstract String getLogLabel();
+
+    /**
+     * 是否将起点作为首个执行目标加入队列。
+     */
+    protected boolean shouldIncludeOriginTarget() {
+        return false;
+    }
 
     /**
      * 记录规划完成日志。

--- a/src/main/java/club/heiqi/qz_miner/chain/planner/ChainPlanningRuntimeFactory.java
+++ b/src/main/java/club/heiqi/qz_miner/chain/planner/ChainPlanningRuntimeFactory.java
@@ -5,6 +5,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
 import club.heiqi.qz_miner.Config;
+import club.heiqi.qz_miner.compat.gregtech.GregTechCableCompatHelper;
 import club.heiqi.qz_miner.chain.mode.ChainModeDefinition;
 import club.heiqi.qz_miner.chain.mode.ChainModeRegistry;
 import club.heiqi.qz_miner.chain.mode.ChainSubMode;
@@ -156,6 +157,11 @@ public final class ChainPlanningRuntimeFactory {
                     context.getSampleMeta(),
                     context.getSampleTileEntity(),
                     target);
+            }
+
+            if (subMode == ChainSubMode.SPECIAL_GT_CABLE_REPLACE) {
+                TileEntity tileEntity = context.getWorld().getTileEntity(target.getX(), target.getY(), target.getZ());
+                return GregTechCableCompatHelper.isCable(tileEntity);
             }
 
             return true;

--- a/src/main/java/club/heiqi/qz_miner/chain/planner/GregTechCableMatcher.java
+++ b/src/main/java/club/heiqi/qz_miner/chain/planner/GregTechCableMatcher.java
@@ -1,0 +1,28 @@
+package club.heiqi.qz_miner.chain.planner;
+
+import club.heiqi.qz_miner.compat.gregtech.GregTechCableCompatHelper;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.tileentity.TileEntity;
+
+/**
+ * GT 线缆目标匹配器。
+ */
+public class GregTechCableMatcher implements ChainBlockMatcher {
+
+    private final int sampleMetaTileId;
+
+    public GregTechCableMatcher(int sampleMetaTileId) {
+        this.sampleMetaTileId = sampleMetaTileId;
+    }
+
+    @Override
+    public boolean matches(EntityPlayer player, ChainTarget target) {
+        if (player == null || target == null) {
+            return false;
+        }
+
+        TileEntity tileEntity = player.worldObj.getTileEntity(target.getX(), target.getY(), target.getZ());
+        return GregTechCableCompatHelper.isCable(tileEntity)
+            && GregTechCableCompatHelper.getCableMetaTileId(tileEntity) == sampleMetaTileId;
+    }
+}

--- a/src/main/java/club/heiqi/qz_miner/chain/planner/GregTechCablePlanningStrategy.java
+++ b/src/main/java/club/heiqi/qz_miner/chain/planner/GregTechCablePlanningStrategy.java
@@ -1,0 +1,82 @@
+package club.heiqi.qz_miner.chain.planner;
+
+import java.util.UUID;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+import club.heiqi.qz_miner.MyMod;
+import club.heiqi.qz_miner.chain.mode.ChainMode;
+import club.heiqi.qz_miner.chain.state.ChainPlayerState;
+import club.heiqi.qz_miner.chain.state.ChainSession;
+import net.minecraft.entity.player.EntityPlayerMP;
+
+/**
+ * GT 线缆特殊模式规划策略。
+ */
+public class GregTechCablePlanningStrategy extends AbstractFloodFillPlanningStrategy {
+
+    public GregTechCablePlanningStrategy() {
+        super(ChainMode.SPECIAL);
+    }
+
+    @Override
+    public void startPlanning(EntityPlayerMP player, ChainPlayerState playerState, ChainTarget origin) {
+        ChainSession session = new ChainSession(
+            player.getUniqueID(),
+            playerState.getSelectedMode(),
+            playerState.getSelectedSubMode(),
+            origin,
+            1,
+            0.0F,
+            0.0F,
+            0.0F,
+            playerState.getRequestedChainRadius(),
+            playerState.getRequestedChainMaxBlocks());
+        startPlanningInternal(player, playerState, origin, session);
+    }
+
+    @Override
+    protected boolean checkCanOperate(EntityPlayerMP player, ChainPlayerState playerState) {
+        return player != null && playerState.isChainKeyPressed();
+    }
+
+    @Override
+    protected String getRestartReason() {
+        return "restart-special-cable-plan";
+    }
+
+    @Override
+    protected String getStartReason() {
+        return "start-special-cable-plan";
+    }
+
+    @Override
+    protected String getTaskPrefix() {
+        return "special-cable-plan-";
+    }
+
+    @Override
+    protected String getStopReasonPrefix() {
+        return "special-cable-plan-";
+    }
+
+    @Override
+    protected String getPlannerReasonPrefix() {
+        return "special-cable-planner-";
+    }
+
+    @Override
+    protected String getLogLabel() {
+        return "special-cable";
+    }
+
+    @Override
+    protected boolean shouldIncludeOriginTarget() {
+        return true;
+    }
+
+    @Override
+    protected void logPlanCompleted(UUID playerUUID, ChainSearchContext searchContext, ConcurrentLinkedQueue<ChainTarget> queue, ChainPlayerState currentState) {
+        MyMod.LOG.debug("[ChainPlanner] Special cable plan completed for player {}, confirmed={}, queuedTargets={}",
+            playerUUID, searchContext.getConfirmedCount(), queue.size());
+    }
+}

--- a/src/main/java/club/heiqi/qz_miner/chain/planner/GregTechCableReplacePlanner.java
+++ b/src/main/java/club/heiqi/qz_miner/chain/planner/GregTechCableReplacePlanner.java
@@ -4,29 +4,34 @@ import club.heiqi.qz_miner.MyMod;
 import club.heiqi.qz_miner.chain.mode.ChainMode;
 import club.heiqi.qz_miner.chain.mode.ChainModeDefinition;
 import club.heiqi.qz_miner.chain.mode.ChainModeRegistry;
+import club.heiqi.qz_miner.chain.mode.ChainSubMode;
 import club.heiqi.qz_miner.chain.state.ChainPlayerState;
+import club.heiqi.qz_miner.compat.gregtech.GregTechCableCompatHelper;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.util.FakePlayer;
-import net.minecraftforge.event.world.BlockEvent;
+import net.minecraftforge.event.entity.player.PlayerInteractEvent;
 
 /**
- * 连锁规划器调度器。
+ * GT 线缆替换模式左键规划入口。
  */
-public class ChainPlanner {
+public class GregTechCableReplacePlanner {
 
-    public ChainPlanner() {
+    public GregTechCableReplacePlanner() {
         MinecraftForge.EVENT_BUS.register(this);
     }
 
     @SubscribeEvent
-    public void onBlockBreak(BlockEvent.BreakEvent event) {
-        if (event.getPlayer() == null || !(event.getPlayer() instanceof EntityPlayerMP)) {
+    public void onPlayerLeftClickBlock(PlayerInteractEvent event) {
+        if (event.entityPlayer == null || !(event.entityPlayer instanceof EntityPlayerMP)) {
+            return;
+        }
+        if (event.action != PlayerInteractEvent.Action.LEFT_CLICK_BLOCK) {
             return;
         }
 
-        EntityPlayerMP player = (EntityPlayerMP) event.getPlayer();
+        EntityPlayerMP player = (EntityPlayerMP) event.entityPlayer;
         if (player instanceof FakePlayer || MyMod.chainStateService == null) {
             return;
         }
@@ -35,7 +40,12 @@ public class ChainPlanner {
         if (!playerState.isChainKeyPressed() || playerState.isExecuting()) {
             return;
         }
-        if (playerState.getSelectedMode() == ChainMode.SPECIAL) {
+        if (playerState.getSelectedMode() != ChainMode.SPECIAL
+            || playerState.getSelectedSubMode() != ChainSubMode.SPECIAL_GT_CABLE_REPLACE) {
+            return;
+        }
+
+        if (!GregTechCableCompatHelper.isCable(player.worldObj.getTileEntity(event.x, event.y, event.z))) {
             return;
         }
 
@@ -44,6 +54,7 @@ public class ChainPlanner {
             return;
         }
 
+        event.setCanceled(true);
         definition.getPlanningStrategy().startPlanning(player, playerState, new ChainTarget(event.x, event.y, event.z));
     }
 }

--- a/src/main/java/club/heiqi/qz_miner/chain/planner/GregTechCableTraverser.java
+++ b/src/main/java/club/heiqi/qz_miner/chain/planner/GregTechCableTraverser.java
@@ -1,0 +1,107 @@
+package club.heiqi.qz_miner.chain.planner;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import club.heiqi.qz_miner.compat.gregtech.GregTechCableCompatHelper;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraftforge.common.util.ForgeDirection;
+
+/**
+ * 按 GT 线缆真实连接关系遍历。
+ */
+public class GregTechCableTraverser implements ChainTraverser {
+
+    @Override
+    public void seed(ChainSearchContext context) {
+        ChainTarget origin = context.getOrigin();
+        if (origin == null) {
+            return;
+        }
+
+        context.getVisited().add(origin);
+        for (ChainTarget neighbor : resolveConnectedNeighbors(context, origin)) {
+            if (!context.getVisited().add(neighbor)) {
+                continue;
+            }
+            if (!context.canTraverse(neighbor)) {
+                continue;
+            }
+            context.getCurrentFrontier().add(neighbor);
+        }
+    }
+
+    @Override
+    public boolean step(ChainSearchContext context, int maxNodes, ChainTargetMatcher matcher, ChainTargetConsumer consumer) {
+        int processed = 0;
+
+        if (context.getConfirmedCount() >= context.getMaxTargets()) {
+            return false;
+        }
+
+        while (processed < maxNodes && !context.getCurrentFrontier().isEmpty()) {
+            ChainTarget current = context.getCurrentFrontier().poll();
+            if (current == null) {
+                break;
+            }
+
+            if (!context.canTraverse(current) || !matcher.matches(current)) {
+                processed++;
+                continue;
+            }
+
+            consumer.accept(current);
+            context.incrementConfirmedCount();
+            if (context.getConfirmedCount() >= context.getMaxTargets()) {
+                processed++;
+                break;
+            }
+
+            for (ChainTarget next : resolveConnectedNeighbors(context, current)) {
+                if (!context.getVisited().add(next)) {
+                    continue;
+                }
+                if (!context.canTraverse(next)) {
+                    continue;
+                }
+                if (getDistance(next, context.getOrigin()) > context.getMaxRadius()) {
+                    continue;
+                }
+                context.getNextFrontier().add(next);
+            }
+
+            processed++;
+        }
+
+        if (context.getCurrentFrontier().isEmpty() && !context.getNextFrontier().isEmpty()) {
+            while (!context.getNextFrontier().isEmpty()) {
+                context.getCurrentFrontier().add(context.getNextFrontier().poll());
+            }
+        }
+
+        return !context.getCurrentFrontier().isEmpty();
+    }
+
+    private List<ChainTarget> resolveConnectedNeighbors(ChainSearchContext context, ChainTarget source) {
+        TileEntity tileEntity = context.getWorld().getTileEntity(source.getX(), source.getY(), source.getZ());
+        if (!GregTechCableCompatHelper.isCable(tileEntity)) {
+            return java.util.Collections.emptyList();
+        }
+
+        List<ChainTarget> neighbors = new ArrayList<ChainTarget>();
+        for (ForgeDirection side : GregTechCableCompatHelper.getConnectedSides(tileEntity)) {
+            neighbors.add(new ChainTarget(
+                source.getX() + side.offsetX,
+                source.getY() + side.offsetY,
+                source.getZ() + side.offsetZ));
+        }
+        return neighbors;
+    }
+
+    private int getDistance(ChainTarget a, ChainTarget b) {
+        int dx = Math.abs(a.getX() - b.getX());
+        int dy = Math.abs(a.getY() - b.getY());
+        int dz = Math.abs(a.getZ() - b.getZ());
+        return Math.max(dx, Math.max(dy, dz));
+    }
+}

--- a/src/main/java/club/heiqi/qz_miner/chain/state/ChainPlayerState.java
+++ b/src/main/java/club/heiqi/qz_miner/chain/state/ChainPlayerState.java
@@ -3,6 +3,7 @@ package club.heiqi.qz_miner.chain.state;
 import java.util.UUID;
 
 import club.heiqi.qz_miner.MyMod;
+import club.heiqi.qz_miner.chain.executor.GregTechCableSessionState;
 import club.heiqi.qz_miner.chain.mode.ChainMode;
 import club.heiqi.qz_miner.chain.mode.ChainSubMode;
 
@@ -153,6 +154,7 @@ public class ChainPlayerState extends AbstractChainModeState {
     public void clearRuntimeState(String reason) {
         setExecutionStatus(ChainExecutionStatus.IDLE, reason);
         if (session != null) {
+            GregTechCableSessionState.clear(session);
             session.clearRuntimeState(reason);
             clearSession();
         }
@@ -170,6 +172,7 @@ public class ChainPlayerState extends AbstractChainModeState {
             return;
         }
 
+        GregTechCableSessionState.clear(session);
         session.getRuntimeState().stopExecutionPreservingDrops(reason);
         if (session.getRuntimeState().getPendingDrops().isEmpty()) {
             clearSession();

--- a/src/main/java/club/heiqi/qz_miner/compat/gregtech/GregTechCableCompatHelper.java
+++ b/src/main/java/club/heiqi/qz_miner/compat/gregtech/GregTechCableCompatHelper.java
@@ -1,0 +1,185 @@
+package club.heiqi.qz_miner.compat.gregtech;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import gregtech.api.GregTechAPI;
+import gregtech.api.interfaces.metatileentity.IConnectable;
+import gregtech.api.interfaces.metatileentity.IMetaTileEntity;
+import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
+import gregtech.api.metatileentity.BaseMetaPipeEntity;
+import gregtech.api.metatileentity.implementations.MTECable;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.item.ItemStack;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraftforge.common.util.ForgeDirection;
+
+/**
+ * GregTech 线缆兼容辅助。
+ */
+public final class GregTechCableCompatHelper {
+
+    private GregTechCableCompatHelper() {}
+
+    /**
+     * 判断目标坐标是否为 GT 线缆。
+     */
+    public static boolean isCable(TileEntity tileEntity) {
+        return getCable(tileEntity) != null;
+    }
+
+    /**
+     * 获取 GT 线缆元实体。
+     */
+    public static MTECable getCable(TileEntity tileEntity) {
+        if (!(tileEntity instanceof IGregTechTileEntity gregTechTileEntity)) {
+            return null;
+        }
+
+        IMetaTileEntity metaTileEntity = gregTechTileEntity.getMetaTileEntity();
+        if (!(metaTileEntity instanceof MTECable cable)) {
+            return null;
+        }
+        return cable;
+    }
+
+    /**
+     * 获取 GT 线缆宿主方块。
+     */
+    public static BaseMetaPipeEntity getCableBase(TileEntity tileEntity) {
+        return tileEntity instanceof BaseMetaPipeEntity baseMetaPipeEntity && isCable(tileEntity)
+            ? baseMetaPipeEntity
+            : null;
+    }
+
+    /**
+     * 获取当前线缆已连接方向。
+     */
+    public static List<ForgeDirection> getConnectedSides(TileEntity tileEntity) {
+        BaseMetaPipeEntity baseMetaPipeEntity = getCableBase(tileEntity);
+        if (baseMetaPipeEntity == null) {
+            return Collections.emptyList();
+        }
+
+        List<ForgeDirection> connectedSides = new ArrayList<ForgeDirection>();
+        byte connections = baseMetaPipeEntity.mConnections;
+        for (ForgeDirection side : ForgeDirection.VALID_DIRECTIONS) {
+            if ((connections & side.flag) != 0) {
+                connectedSides.add(side);
+            }
+        }
+        return connectedSides;
+    }
+
+    /**
+     * 读取线缆元方块 ID。
+     */
+    public static int getCableMetaTileId(TileEntity tileEntity) {
+        if (!(tileEntity instanceof IGregTechTileEntity gregTechTileEntity)) {
+            return -1;
+        }
+        return gregTechTileEntity.getMetaTileID();
+    }
+
+    /**
+     * 判断物品栈是否为 GT 线缆。
+     */
+    public static boolean isCableStack(ItemStack stack) {
+        return createCableFromStack(stack) != null;
+    }
+
+    /**
+     * 从线缆物品栈解析临时元实体。
+     */
+    public static MTECable createCableFromStack(ItemStack stack) {
+        if (stack == null || stack.getItem() == null) {
+            return null;
+        }
+
+        IMetaTileEntity metaTileEntity = gregtech.common.blocks.ItemMachines.getMetaTileEntity(stack);
+        return metaTileEntity instanceof MTECable cable ? cable : null;
+    }
+
+    /**
+     * 复刻 GT 原生线缆替换逻辑，保持旧连接状态。
+     */
+    public static boolean replaceCableKeepingConnections(EntityPlayerMP player, BaseMetaPipeEntity baseMetaPipeEntity, ItemStack replacementStack, int replacementSlotIndex) {
+        if (player == null || baseMetaPipeEntity == null || replacementStack == null) {
+            return false;
+        }
+
+        MTECable oldCable = getCable(baseMetaPipeEntity);
+        MTECable handCable = createCableFromStack(replacementStack);
+        if (oldCable == null || handCable == null) {
+            return false;
+        }
+
+        if (oldCable.getClass() == handCable.getClass()
+            && oldCable.mMaterial == handCable.mMaterial
+            && oldCable.mVoltage == handCable.mVoltage
+            && oldCable.mAmperage == handCable.mAmperage) {
+            return false;
+        }
+
+        byte oldConnections = oldCable.mConnections;
+        short oldMetaId = (short) baseMetaPipeEntity.getMetaTileID();
+        short newMetaId = (short) replacementStack.getItemDamage();
+
+        IMetaTileEntity newMetaTileEntity = handCable.newMetaEntity(baseMetaPipeEntity);
+        if (!(newMetaTileEntity instanceof MTECable newCable)) {
+            return false;
+        }
+
+        newCable.mConnections = oldConnections;
+
+        baseMetaPipeEntity.setMetaTileID(newMetaId);
+        baseMetaPipeEntity.setMetaTileEntity(newCable);
+        baseMetaPipeEntity.mConnections = oldConnections;
+        baseMetaPipeEntity.markDirty();
+        baseMetaPipeEntity.issueTextureUpdate();
+        baseMetaPipeEntity.issueBlockUpdate();
+        baseMetaPipeEntity.issueClientUpdate();
+        GregTechAPI.causeCableUpdate(baseMetaPipeEntity.getWorld(), baseMetaPipeEntity.xCoord, baseMetaPipeEntity.yCoord, baseMetaPipeEntity.zCoord);
+        for (ForgeDirection side : ForgeDirection.VALID_DIRECTIONS) {
+            TileEntity neighborTileEntity = baseMetaPipeEntity.getTileEntityAtSide(side);
+            if (neighborTileEntity instanceof BaseMetaPipeEntity neighborPipeEntity) {
+                neighborPipeEntity.issueClientUpdate();
+                neighborPipeEntity.issueTextureUpdate();
+                neighborPipeEntity.issueBlockUpdate();
+                GregTechAPI.causeCableUpdate(neighborPipeEntity.getWorld(), neighborPipeEntity.xCoord, neighborPipeEntity.yCoord, neighborPipeEntity.zCoord);
+            }
+        }
+
+        if (!player.capabilities.isCreativeMode) {
+            ItemStack oldCableStack = new ItemStack(replacementStack.getItem(), 1, oldMetaId);
+            boolean addedToInventory = false;
+
+            for (int i = 0; i < player.inventory.mainInventory.length; i++) {
+                ItemStack slot = player.inventory.mainInventory[i];
+                if (slot != null
+                    && slot.getItem() == oldCableStack.getItem()
+                    && slot.getItemDamage() == oldCableStack.getItemDamage()
+                    && slot.stackSize < slot.getMaxStackSize()) {
+                    slot.stackSize++;
+                    addedToInventory = true;
+                    break;
+                }
+            }
+
+            if (!addedToInventory) {
+                addedToInventory = player.inventory.addItemStackToInventory(oldCableStack);
+            }
+            if (!addedToInventory) {
+                player.dropPlayerItemWithRandomChoice(oldCableStack, false);
+            }
+
+            replacementStack.stackSize--;
+            if (replacementStack.stackSize <= 0) {
+                player.inventory.setInventorySlotContents(replacementSlotIndex, null);
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/main/resources/assets/qz_miner/lang/en_US.lang
+++ b/src/main/resources/assets/qz_miner/lang/en_US.lang
@@ -23,5 +23,6 @@ hud.qz_miner.sub_mode.area.tunnel=Tunnel Blasting Mode
 hud.qz_miner.sub_mode.interact.base=Chain Block Interaction Mode
 hud.qz_miner.sub_mode.interact.crop=Crop Interaction Mode
 hud.qz_miner.sub_mode.special.lootgames_minesweeper=Special Minesweeper Preview Mode
+hud.qz_miner.sub_mode.special.gt_cable_replace=GT Cable Replace Mode
 key.categories.qz_miner=Qz-Miner
 key.qz_miner.chainSwitch=Chain Key

--- a/src/main/resources/assets/qz_miner/lang/zh_CN.lang
+++ b/src/main/resources/assets/qz_miner/lang/zh_CN.lang
@@ -23,5 +23,6 @@ hud.qz_miner.sub_mode.area.tunnel=爆破隧道模式
 hud.qz_miner.sub_mode.interact.base=连锁块交互模式
 hud.qz_miner.sub_mode.interact.crop=作物交互模式
 hud.qz_miner.sub_mode.special.lootgames_minesweeper=特殊扫雷预览模式
+hud.qz_miner.sub_mode.special.gt_cable_replace=GT线缆连锁替换模式
 key.categories.qz_miner=Qz-Miner
 key.qz_miner.chainSwitch=连锁按键


### PR DESCRIPTION
- 为 SPECIAL 模式接入 GT 线缆连锁替换子模式，新增左键触发入口、专用搜索遍历器与执行器
- 按种子线缆类型与真实连接方向进行整线预览和批量替换，并实现快捷栏优先、背包兜底的线缆类型锁定逻辑
- 复刻 GT 原生替换流程并补充连接状态继承、客户端同步与线网更新，确保替换后连接与渲染即时恢复