### PR TITLE
[Fix]: 避免专用服触发客户端专有交互调用

### DIFF
--- a/src/main/java/club/heiqi/qz_miner/ClientProxy.java
+++ b/src/main/java/club/heiqi/qz_miner/ClientProxy.java
@@ -1,14 +1,20 @@
 package club.heiqi.qz_miner;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import club.heiqi.qz_miner.chain.client.ChainPreviewController;
 import club.heiqi.qz_miner.chain.client.ChainPreviewRenderer;
 import club.heiqi.qz_miner.chain.mode.ChainMode;
 import club.heiqi.qz_miner.chain.mode.ChainSubMode;
+import club.heiqi.qz_miner.chain.planner.ChainTarget;
 import club.heiqi.qz_miner.chain.state.ChainExecutionStatus;
 import club.heiqi.qz_miner.client.ClientConnectionListener;
+import club.heiqi.qz_miner.client.ClientConfigChangeListener;
 import club.heiqi.qz_miner.client.HudOverlay;
 import club.heiqi.qz_miner.client.KeyListener;
 import cpw.mods.fml.common.event.FMLInitializationEvent;
+import net.minecraft.client.Minecraft;
 
 public class ClientProxy extends CommonProxy {
 
@@ -23,6 +29,7 @@ public class ClientProxy extends CommonProxy {
         chainPreviewRenderer = new ChainPreviewRenderer();
         chainPreviewRenderer.register();
         new ClientConnectionListener().register();
+        new ClientConfigChangeListener().register();
         HudOverlay hudOverlay = new HudOverlay();
         hudOverlay.register();
         new KeyListener(hudOverlay).register();
@@ -42,5 +49,21 @@ public class ClientProxy extends CommonProxy {
         MyMod.chainStateService.getClientState().setServerChainRadius(chainRadius);
         MyMod.chainStateService.getClientState().setServerChainMaxBlocks(chainMaxBlocks);
         MyMod.chainStateService.getClientState().setServerMatchedTargetCount(matchedTargetCount);
+    }
+
+    @Override
+    public void handleClientLootGamesMinesweeperPreview(int requestId, ChainTarget origin, List<ChainTarget> targets) {
+        final List<ChainTarget> targetSnapshot = targets == null ? new ArrayList<ChainTarget>() : new ArrayList<ChainTarget>(targets);
+        Minecraft.getMinecraft().func_152344_a(new Runnable() {
+
+            @Override
+            public void run() {
+                if (chainPreviewController == null) {
+                    return;
+                }
+
+                chainPreviewController.applyLootGamesMinesweeperPreview(requestId, origin, targetSnapshot);
+            }
+        });
     }
 }

--- a/src/main/java/club/heiqi/qz_miner/CommonProxy.java
+++ b/src/main/java/club/heiqi/qz_miner/CommonProxy.java
@@ -1,7 +1,10 @@
 package club.heiqi.qz_miner;
 
+import java.util.List;
+
 import club.heiqi.qz_miner.chain.mode.ChainMode;
 import club.heiqi.qz_miner.chain.mode.ChainSubMode;
+import club.heiqi.qz_miner.chain.planner.ChainTarget;
 import club.heiqi.qz_miner.chain.state.ChainExecutionStatus;
 import cpw.mods.fml.common.event.FMLInitializationEvent;
 import cpw.mods.fml.common.event.FMLPostInitializationEvent;
@@ -29,6 +32,12 @@ public class CommonProxy {
      * 处理客户端连锁状态同步。
      */
     public void handleClientChainStateSync(boolean chainKeyPressed, boolean executing, ChainMode mode, ChainSubMode subMode, ChainExecutionStatus executionStatus, int chainRadius, int chainMaxBlocks, int matchedTargetCount) {
+    }
+
+    /**
+     * 处理客户端扫雷预览结果。
+     */
+    public void handleClientLootGamesMinesweeperPreview(int requestId, ChainTarget origin, List<ChainTarget> targets) {
     }
 
     // register server commands in this event handler (Remove if not needed)

--- a/src/main/java/club/heiqi/qz_miner/Config.java
+++ b/src/main/java/club/heiqi/qz_miner/Config.java
@@ -2,14 +2,6 @@ package club.heiqi.qz_miner;
 
 import java.io.File;
 
-import cpw.mods.fml.client.FMLClientHandler;
-import cpw.mods.fml.client.event.ConfigChangedEvent;
-import cpw.mods.fml.common.FMLCommonHandler;
-import cpw.mods.fml.common.eventhandler.SubscribeEvent;
-import cpw.mods.fml.relauncher.Side;
-import cpw.mods.fml.relauncher.SideOnly;
-import club.heiqi.qz_miner.network.PacketChainConfigRequest;
-import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.config.Configuration;
 
 public class Config {
@@ -43,8 +35,6 @@ public class Config {
         if (config == null) {
             configPath = configFile.getAbsolutePath();
             config = new Configuration(configFile);
-            MinecraftForge.EVENT_BUS.register(this);
-            FMLCommonHandler.instance().bus().register(this);
         }
 
         load();
@@ -79,32 +69,4 @@ public class Config {
         }
     }
 
-    /**
-     * 从 Forge 配置界面保存后重新加载配置。
-     *
-     * @param event 配置变更事件
-     */
-    @SubscribeEvent
-    public void onConfigChangeEvent(ConfigChangedEvent.OnConfigChangedEvent event) {
-        if (!MyMod.MODID.equalsIgnoreCase(event.modID)) {
-            return;
-        }
-
-        load();
-        syncClientRequestedChainConfig();
-    }
-
-    @SideOnly(Side.CLIENT)
-    private void syncClientRequestedChainConfig() {
-        if (MyMod.chainStateService == null) {
-            return;
-        }
-
-        MyMod.chainStateService.setClientRequestedChainConfig(chainRadius, chainMaxBlocks);
-        if (MyMod.networkMain == null || FMLClientHandler.instance().getClient().isSingleplayer()) {
-            return;
-        }
-
-        MyMod.networkMain.network.sendToServer(new PacketChainConfigRequest(chainRadius, chainMaxBlocks));
-    }
 }

--- a/src/main/java/club/heiqi/qz_miner/chain/planner/ChainInteractPlanner.java
+++ b/src/main/java/club/heiqi/qz_miner/chain/planner/ChainInteractPlanner.java
@@ -19,6 +19,8 @@ import net.minecraftforge.event.entity.player.PlayerInteractEvent;
  */
 public class ChainInteractPlanner {
 
+    private static final double INTERACT_REACH_DISTANCE = 5.0D;
+
     public ChainInteractPlanner() {
         MinecraftForge.EVENT_BUS.register(this);
     }
@@ -107,9 +109,22 @@ public class ChainInteractPlanner {
      * @return 命中点偏移
      */
     private HitOffset resolveHitOffset(EntityPlayerMP player, PlayerInteractEvent event) {
-        MovingObjectPosition movingObjectPosition = player.rayTrace(5.0D, 1.0F);
+        Vec3 eyePosition = Vec3.createVectorHelper(player.posX, player.posY + player.getEyeHeight(), player.posZ);
+        Vec3 lookVec = player.getLookVec();
+        if (lookVec == null) {
+            return createFaceFallback(normalizeFace(event.face));
+        }
+
+        Vec3 reachPosition = eyePosition.addVector(
+            lookVec.xCoord * INTERACT_REACH_DISTANCE,
+            lookVec.yCoord * INTERACT_REACH_DISTANCE,
+            lookVec.zCoord * INTERACT_REACH_DISTANCE);
+        MovingObjectPosition movingObjectPosition = player.worldObj.func_147447_a(eyePosition, reachPosition, false, false, true);
         if (movingObjectPosition == null || movingObjectPosition.hitVec == null) {
-            return HitOffset.ZERO;
+            return createFaceFallback(normalizeFace(event.face));
+        }
+        if (movingObjectPosition.blockX != event.x || movingObjectPosition.blockY != event.y || movingObjectPosition.blockZ != event.z) {
+            return createFaceFallback(normalizeFace(event.face));
         }
 
         Vec3 hitVec = movingObjectPosition.hitVec;
@@ -117,6 +132,31 @@ public class ChainInteractPlanner {
             normalizeHit(event.x, hitVec.xCoord),
             normalizeHit(event.y, hitVec.yCoord),
             normalizeHit(event.z, hitVec.zCoord));
+    }
+
+    /**
+     * 在射线结果不可用时，回退到点击面的中心点。
+     *
+     * @param face 点击面
+     * @return 对应面的中心偏移
+     */
+    private HitOffset createFaceFallback(int face) {
+        switch (face) {
+            case 0:
+                return new HitOffset(0.5F, 0.0F, 0.5F);
+            case 1:
+                return new HitOffset(0.5F, 1.0F, 0.5F);
+            case 2:
+                return new HitOffset(0.5F, 0.5F, 0.0F);
+            case 3:
+                return new HitOffset(0.5F, 0.5F, 1.0F);
+            case 4:
+                return new HitOffset(0.0F, 0.5F, 0.5F);
+            case 5:
+                return new HitOffset(1.0F, 0.5F, 0.5F);
+            default:
+                return HitOffset.ZERO;
+        }
     }
 
     /**

--- a/src/main/java/club/heiqi/qz_miner/client/ClientConfigChangeListener.java
+++ b/src/main/java/club/heiqi/qz_miner/client/ClientConfigChangeListener.java
@@ -1,0 +1,56 @@
+package club.heiqi.qz_miner.client;
+
+import club.heiqi.qz_miner.Config;
+import club.heiqi.qz_miner.MyMod;
+import club.heiqi.qz_miner.network.PacketChainConfigRequest;
+import cpw.mods.fml.client.FMLClientHandler;
+import cpw.mods.fml.client.event.ConfigChangedEvent;
+import cpw.mods.fml.common.FMLCommonHandler;
+import cpw.mods.fml.common.eventhandler.SubscribeEvent;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+
+/**
+ * 客户端配置变更监听。
+ */
+@SideOnly(Side.CLIENT)
+public class ClientConfigChangeListener {
+
+    /**
+     * 注册配置变更监听。
+     */
+    public void register() {
+        FMLCommonHandler.instance().bus().register(this);
+    }
+
+    /**
+     * 从 Forge 配置界面保存后重新加载配置，并同步到服务端。
+     *
+     * @param event 配置变更事件
+     */
+    @SubscribeEvent
+    public void onConfigChangeEvent(ConfigChangedEvent.OnConfigChangedEvent event) {
+        if (!MyMod.MODID.equalsIgnoreCase(event.modID)) {
+            return;
+        }
+
+        MyMod.CONFIG.load();
+        syncClientRequestedChainConfig();
+    }
+
+    /**
+     * 将客户端请求的连锁配置同步到本地状态与服务端。
+     */
+    private void syncClientRequestedChainConfig() {
+        if (MyMod.chainStateService == null) {
+            return;
+        }
+
+        MyMod.chainStateService.setClientRequestedChainConfig(Config.chainRadius, Config.chainMaxBlocks);
+        if (MyMod.networkMain == null || FMLClientHandler.instance().getClient().isSingleplayer()) {
+            return;
+        }
+
+        MyMod.networkMain.network.sendToServer(new PacketChainConfigRequest(Config.chainRadius, Config.chainMaxBlocks));
+    }
+}

--- a/src/main/java/club/heiqi/qz_miner/network/PacketLootGamesMinesweeperPreviewResponse.java
+++ b/src/main/java/club/heiqi/qz_miner/network/PacketLootGamesMinesweeperPreviewResponse.java
@@ -3,13 +3,12 @@ package club.heiqi.qz_miner.network;
 import java.util.ArrayList;
 import java.util.List;
 
-import club.heiqi.qz_miner.ClientProxy;
+import club.heiqi.qz_miner.MyMod;
 import club.heiqi.qz_miner.chain.planner.ChainTarget;
+import io.netty.buffer.ByteBuf;
 import cpw.mods.fml.common.network.simpleimpl.IMessage;
 import cpw.mods.fml.common.network.simpleimpl.IMessageHandler;
 import cpw.mods.fml.common.network.simpleimpl.MessageContext;
-import cpw.mods.fml.client.FMLClientHandler;
-import io.netty.buffer.ByteBuf;
 
 /**
  * LootGames 扫雷预览结果响应包。
@@ -68,20 +67,10 @@ public class PacketLootGamesMinesweeperPreviewResponse implements IMessage {
 
         @Override
         public IMessage onMessage(final PacketLootGamesMinesweeperPreviewResponse message, MessageContext ctx) {
-            FMLClientHandler.instance().getClient().func_152344_a(new Runnable() {
-
-                @Override
-                public void run() {
-                    if (ClientProxy.chainPreviewController == null) {
-                        return;
-                    }
-
-                    ClientProxy.chainPreviewController.applyLootGamesMinesweeperPreview(
-                        message.requestId,
-                        new ChainTarget(message.originX, message.originY, message.originZ),
-                        message.targets);
-                }
-            });
+            MyMod.proxy.handleClientLootGamesMinesweeperPreview(
+                message.requestId,
+                new ChainTarget(message.originX, message.originY, message.originZ),
+                new ArrayList<ChainTarget>(message.targets));
             return null;
         }
     }


### PR DESCRIPTION
- 修复 INTERACT 作物右键在服务端恢复命中点时直接调用 0EntityPlayerMP#rayTrace0 的崩服问题，改为手动射线并在失配时回退到点击面中心。
- 将配置变更同步与扫雷预览响应的客户端逻辑下沉到客户端监听器/代理，移除公共类中的客户端依赖，降低专用服缺类或缺方法风险。
- 复查公共与规划路径后，未再发现 0rayTrace0、0getPosition0、0getLook0 等客户端专有实体方法调用