### PR TITLE
[Fix]: 修复连锁会话生命周期竞态崩溃

### DIFF
--- a/src/main/java/club/heiqi/qz_miner/chain/executor/ChainDropCollector.java
+++ b/src/main/java/club/heiqi/qz_miner/chain/executor/ChainDropCollector.java
@@ -77,7 +77,7 @@ public class ChainDropCollector {
             MyMod.LOG.debug("[ChainDropCollector] Ready to release aggregated drops for player {}, pending aggregated stacks={}",
                 playerState.getPlayerUUID(), session.getRuntimeState().getPendingDrops().size());
             releaseDrops((EntityPlayerMP) player, session);
-            if (session != null
+            if (playerState.isSessionActive(session)
                 && session.getRuntimeState().getPendingBreakTargets().isEmpty()
                 && !session.getRuntimeState().isPlannerRunning()) {
                 playerState.clearSession();

--- a/src/main/java/club/heiqi/qz_miner/chain/executor/ChainExecutor.java
+++ b/src/main/java/club/heiqi/qz_miner/chain/executor/ChainExecutor.java
@@ -10,6 +10,7 @@ import club.heiqi.qz_miner.chain.mode.ChainSubMode;
 import club.heiqi.qz_miner.chain.planner.ChainTarget;
 import club.heiqi.qz_miner.chain.state.ChainExecutionStatus;
 import club.heiqi.qz_miner.chain.state.ChainPlayerState;
+import club.heiqi.qz_miner.chain.state.ChainRuntimeState;
 import club.heiqi.qz_miner.chain.state.ChainSession;
 import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
@@ -35,6 +36,10 @@ public class ChainExecutor {
         long nowMillis = System.currentTimeMillis();
 
         for (ChainPlayerState playerState : MyMod.chainStateService.getPlayerStates()) {
+            if (playerState == null) {
+                continue;
+            }
+
             if (playerState.getExecutionStatus() == ChainExecutionStatus.IDLE) {
                 continue;
             }
@@ -42,6 +47,12 @@ public class ChainExecutor {
             ChainSession session = playerState.getSession();
             if (session == null) {
                 MyMod.chainStateService.stopPlayerExecution(playerState.getPlayerUUID(), "missing-session");
+                continue;
+            }
+
+            ChainRuntimeState runtimeState = session.getRuntimeState();
+            if (runtimeState == null) {
+                MyMod.chainStateService.stopPlayerExecution(playerState.getPlayerUUID(), "missing-runtime-state");
                 continue;
             }
 
@@ -56,8 +67,13 @@ public class ChainExecutor {
                 continue;
             }
 
-            ConcurrentLinkedQueue<ChainTarget> queue = session.getRuntimeState().getPendingBreakTargets();
-            if (!session.getRuntimeState().isExecutorReady(nowMillis)) {
+            ConcurrentLinkedQueue<ChainTarget> queue = runtimeState.getPendingBreakTargets();
+            if (!runtimeState.isExecutorReady(nowMillis)) {
+                continue;
+            }
+
+            if (session.getRequest() == null) {
+                MyMod.chainStateService.stopPlayerExecution(playerState.getPlayerUUID(), "missing-request");
                 continue;
             }
 
@@ -94,10 +110,10 @@ public class ChainExecutor {
             }
 
             if (executedCount > 0) {
-                session.getRuntimeState().scheduleNextExecutorRun(nowMillis, 50L);
+                runtimeState.scheduleNextExecutorRun(nowMillis, 50L);
             }
 
-            if (queue.isEmpty() && session.getRuntimeState().isPlannerCompleted()) {
+            if (queue.isEmpty() && runtimeState.isPlannerCompleted()) {
                 MyMod.chainStateService.stopPlayerExecution(playerState.getPlayerUUID(), "executor-consumed-all-targets");
             }
         }

--- a/src/main/java/club/heiqi/qz_miner/chain/planner/AbstractFloodFillPlanningStrategy.java
+++ b/src/main/java/club/heiqi/qz_miner/chain/planner/AbstractFloodFillPlanningStrategy.java
@@ -84,8 +84,13 @@ public abstract class AbstractFloodFillPlanningStrategy implements ChainPlanning
                 }
 
                 ChainPlayerState currentState = MyMod.chainStateService.getPlayerState(playerUUID);
-                if (currentState == null || currentState.getSession() == null) {
+                if (currentState == null) {
                     MyMod.chainStateService.stopPlayerExecution(playerUUID, getStopReasonPrefix() + "state-missing");
+                    return false;
+                }
+
+                if (!currentState.isSessionActive(session)) {
+                    MyMod.LOG.debug("[ChainPlanner] Ignore stale {} session for player {}", getLogLabel(), playerUUID);
                     return false;
                 }
 
@@ -94,7 +99,7 @@ public abstract class AbstractFloodFillPlanningStrategy implements ChainPlanning
                     return false;
                 }
 
-                ChainSession currentSession = currentState.getSession();
+                ChainSession currentSession = session;
                 int previousMatchedCount = currentSession.getRuntimeState().getMatchedTargetCount();
 
                 boolean shouldContinue = traverser.step(
@@ -121,7 +126,9 @@ public abstract class AbstractFloodFillPlanningStrategy implements ChainPlanning
                     searchContext.getCurrentFrontier().clear();
                     if (queue.isEmpty()) {
                         currentState.setExecutionStatus(ChainExecutionStatus.IDLE, getPlannerReasonPrefix() + "completed-empty-queue");
-                        currentState.clearSession();
+                        if (currentState.isSessionActive(currentSession)) {
+                            currentState.clearSession();
+                        }
                         MyMod.chainStateService.syncPlayerState(playerUUID);
                     } else if (currentState.getExecutionStatus() != ChainExecutionStatus.RUNNING) {
                         currentState.setExecutionStatus(ChainExecutionStatus.RUNNING, getPlannerReasonPrefix() + "completed-with-targets");

--- a/src/main/java/club/heiqi/qz_miner/chain/planner/BlockBoxScanPlanningStrategy.java
+++ b/src/main/java/club/heiqi/qz_miner/chain/planner/BlockBoxScanPlanningStrategy.java
@@ -92,8 +92,13 @@ public class BlockBoxScanPlanningStrategy implements ChainPlanningStrategy {
                 }
 
                 ChainPlayerState currentState = MyMod.chainStateService.getPlayerState(playerUUID);
-                if (currentState == null || currentState.getSession() == null) {
+                if (currentState == null) {
                     MyMod.chainStateService.stopPlayerExecution(playerUUID, "area-plan-state-missing");
+                    return false;
+                }
+
+                if (!currentState.isSessionActive(session)) {
+                    MyMod.LOG.debug("[ChainPlanner] Ignore stale area session for player {}", playerUUID);
                     return false;
                 }
 
@@ -102,7 +107,7 @@ public class BlockBoxScanPlanningStrategy implements ChainPlanningStrategy {
                     return false;
                 }
 
-                ChainSession currentSession = currentState.getSession();
+                ChainSession currentSession = session;
                 int previousMatchedCount = currentSession.getRuntimeState().getMatchedTargetCount();
 
                 boolean shouldContinue = traverser.step(
@@ -121,7 +126,7 @@ public class BlockBoxScanPlanningStrategy implements ChainPlanningStrategy {
                 }
 
                 if (!shouldContinue) {
-                    int pendingDrops = currentState.getSession() == null ? 0 : currentState.getSession().getRuntimeState().getPendingDrops().size();
+                    int pendingDrops = currentSession.getRuntimeState().getPendingDrops().size();
                     MyMod.LOG.debug("[ChainPlanner] Area plan completed for player {}, confirmed={}, queuedTargets={}, pendingDrops={}",
                         playerUUID, searchContext.getConfirmedCount(), queue.size(), pendingDrops);
                     currentSession.getRuntimeState().setPlannerSubscription(null);
@@ -131,7 +136,9 @@ public class BlockBoxScanPlanningStrategy implements ChainPlanningStrategy {
                     searchContext.getCurrentFrontier().clear();
                     if (queue.isEmpty()) {
                         currentState.setExecutionStatus(ChainExecutionStatus.IDLE, "area-planner-completed-empty-queue");
-                        currentState.clearSession();
+                        if (currentState.isSessionActive(currentSession)) {
+                            currentState.clearSession();
+                        }
                         MyMod.chainStateService.syncPlayerState(playerUUID);
                     } else if (currentState.getExecutionStatus() != ChainExecutionStatus.RUNNING) {
                         currentState.setExecutionStatus(ChainExecutionStatus.RUNNING, "area-planner-completed-with-targets");

--- a/src/main/java/club/heiqi/qz_miner/chain/planner/BlockFloodFillPlanningStrategy.java
+++ b/src/main/java/club/heiqi/qz_miner/chain/planner/BlockFloodFillPlanningStrategy.java
@@ -71,7 +71,7 @@ public class BlockFloodFillPlanningStrategy extends AbstractFloodFillPlanningStr
 
     @Override
     protected void logPlanCompleted(UUID playerUUID, ChainSearchContext searchContext, ConcurrentLinkedQueue<ChainTarget> queue, ChainPlayerState currentState) {
-        int pendingDrops = currentState.getSession() == null ? 0 : currentState.getSession().getRuntimeState().getPendingDrops().size();
+        int pendingDrops = currentState.getRuntimeState() == null ? 0 : currentState.getRuntimeState().getPendingDrops().size();
         MyMod.LOG.debug("[ChainPlanner] Plan completed for player {}, confirmed={}, queuedTargets={}, pendingDrops={}",
             playerUUID, searchContext.getConfirmedCount(), queue.size(), pendingDrops);
     }

--- a/src/main/java/club/heiqi/qz_miner/chain/state/ChainPlayerState.java
+++ b/src/main/java/club/heiqi/qz_miner/chain/state/ChainPlayerState.java
@@ -56,10 +56,12 @@ public class ChainPlayerState extends AbstractChainModeState {
 
     public void setExecutionStatus(ChainExecutionStatus executionStatus, String reason) {
         ChainExecutionStatus newStatus = executionStatus == null ? ChainExecutionStatus.IDLE : executionStatus;
+        ChainSession currentSession = this.session;
         if (this.executionStatus != newStatus) {
-            int queuedTargets = session == null ? 0 : session.getRuntimeState().getPendingBreakTargets().size();
-            int pendingDropsCount = session == null ? 0 : session.getRuntimeState().getPendingDrops().size();
-            boolean waitingForPlanner = session != null && session.getRuntimeState().isPlannerRunning();
+            ChainRuntimeState runtimeState = currentSession == null ? null : currentSession.getRuntimeState();
+            int queuedTargets = runtimeState == null ? 0 : runtimeState.getPendingBreakTargets().size();
+            int pendingDropsCount = runtimeState == null ? 0 : runtimeState.getPendingDrops().size();
+            boolean waitingForPlanner = runtimeState != null && runtimeState.isPlannerRunning();
             MyMod.LOG.debug(
                 "[ChainState] Player {} executionStatus {} -> {} reason={} queuedTargets={} pendingDrops={} waitingForPlanner={}",
                 playerUUID,
@@ -113,6 +115,15 @@ public class ChainPlayerState extends AbstractChainModeState {
         return session;
     }
 
+    public ChainRuntimeState getRuntimeState() {
+        ChainSession currentSession = this.session;
+        return currentSession == null ? null : currentSession.getRuntimeState();
+    }
+
+    public boolean isSessionActive(ChainSession session) {
+        return session != null && this.session == session;
+    }
+
     public int getRequestedChainRadius() {
         return requestedChainRadius;
     }
@@ -153,10 +164,13 @@ public class ChainPlayerState extends AbstractChainModeState {
 
     public void clearRuntimeState(String reason) {
         setExecutionStatus(ChainExecutionStatus.IDLE, reason);
-        if (session != null) {
-            GregTechCableSessionState.clear(session);
-            session.clearRuntimeState(reason);
-            clearSession();
+        ChainSession currentSession = this.session;
+        if (currentSession != null) {
+            GregTechCableSessionState.clear(currentSession);
+            currentSession.clearRuntimeState(reason);
+            if (this.session == currentSession) {
+                clearSession();
+            }
         }
         MyMod.LOG.debug("[ChainState] Cleared runtime state for player {}, reason={}", playerUUID, reason);
     }
@@ -168,16 +182,18 @@ public class ChainPlayerState extends AbstractChainModeState {
      */
     public void stopExecutionPreservingDrops(String reason) {
         setExecutionStatus(ChainExecutionStatus.IDLE, reason);
-        if (session == null) {
+        ChainSession currentSession = this.session;
+        if (currentSession == null) {
             return;
         }
 
-        GregTechCableSessionState.clear(session);
-        session.getRuntimeState().stopExecutionPreservingDrops(reason);
-        if (session.getRuntimeState().getPendingDrops().isEmpty()) {
+        ChainRuntimeState runtimeState = currentSession.getRuntimeState();
+        GregTechCableSessionState.clear(currentSession);
+        runtimeState.stopExecutionPreservingDrops(reason);
+        if (this.session == currentSession && runtimeState.getPendingDrops().isEmpty()) {
             clearSession();
         }
         MyMod.LOG.debug("[ChainState] Stopped execution for player {}, reason={}, pendingDrops={}",
-            playerUUID, reason, session == null ? 0 : session.getRuntimeState().getPendingDrops().size());
+            playerUUID, reason, runtimeState.getPendingDrops().size());
     }
 }

--- a/src/main/java/club/heiqi/qz_miner/chain/state/ChainStateService.java
+++ b/src/main/java/club/heiqi/qz_miner/chain/state/ChainStateService.java
@@ -42,10 +42,29 @@ public final class ChainStateService {
     }
 
     public void removePlayerState(UUID playerUUID) {
+        removePlayerState(playerUUID, "remove-player-state");
+    }
+
+    public void removePlayerState(UUID playerUUID, String reason) {
         ChainPlayerState state = playerStates.remove(playerUUID);
         if (state != null) {
-            state.clearRuntimeState("remove-player-state");
+            state.clearRuntimeState(reason);
         }
+    }
+
+    public void cleanupPlayerState(UUID playerUUID, String reason, boolean removeState) {
+        ChainPlayerState state = getPlayerState(playerUUID);
+        if (state == null) {
+            return;
+        }
+
+        if (removeState) {
+            removePlayerState(playerUUID, reason);
+            return;
+        }
+
+        state.clearRuntimeState(reason);
+        syncPlayerState(playerUUID);
     }
 
     public ChainClientState getClientState() {
@@ -135,6 +154,8 @@ public final class ChainStateService {
             return;
         }
 
+        ChainRuntimeState runtimeState = state.getRuntimeState();
+
         EntityPlayer player = MyMod.playerManager.getPlayer(playerUUID);
         if (!(player instanceof EntityPlayerMP)) {
             return;
@@ -147,8 +168,8 @@ public final class ChainStateService {
             state.isExecuting(),
             state.getSelectedMode(),
             state.getExecutionStatus(),
-            state.getSession() == null ? 0 : state.getSession().getRuntimeState().getPendingBreakTargets().size(),
-            state.getSession() == null ? 0 : state.getSession().getRuntimeState().getPendingDrops().size());
+            runtimeState == null ? 0 : runtimeState.getPendingBreakTargets().size(),
+            runtimeState == null ? 0 : runtimeState.getPendingDrops().size());
 
         MyMod.networkMain.network.sendTo(
             new PacketChainStateSync(
@@ -159,7 +180,7 @@ public final class ChainStateService {
                 state.getExecutionStatus(),
                 Config.chainRadius,
                 Config.chainMaxBlocks,
-                state.getSession() == null ? 0 : state.getSession().getRuntimeState().getMatchedTargetCount()),
+                runtimeState == null ? 0 : runtimeState.getMatchedTargetCount()),
             (EntityPlayerMP) player);
     }
 
@@ -169,16 +190,18 @@ public final class ChainStateService {
             return;
         }
 
+        ChainRuntimeState runtimeState = state.getRuntimeState();
+
         if (!state.isExecuting()
-            && (state.getSession() == null
-            || (state.getSession().getRuntimeState().getPlannerSubscription() == null
-            && state.getSession().getRuntimeState().getPendingBreakTargets().isEmpty()
-            && state.getSession().getRuntimeState().getPendingDrops().isEmpty()))) {
+            && (runtimeState == null
+            || (runtimeState.getPlannerSubscription() == null
+            && runtimeState.getPendingBreakTargets().isEmpty()
+            && runtimeState.getPendingDrops().isEmpty()))) {
             return;
         }
 
-        int queuedTargets = state.getSession() == null ? 0 : state.getSession().getRuntimeState().getPendingBreakTargets().size();
-        int pendingDrops = state.getSession() == null ? 0 : state.getSession().getRuntimeState().getPendingDrops().size();
+        int queuedTargets = runtimeState == null ? 0 : runtimeState.getPendingBreakTargets().size();
+        int pendingDrops = runtimeState == null ? 0 : runtimeState.getPendingDrops().size();
 
         MyMod.LOG.debug("[ChainState] Stopping player execution for {} reason={} status={} queuedTargets={} pendingDrops={}",
             playerUUID,
@@ -194,14 +217,23 @@ public final class ChainStateService {
         UUID playerUUID = event.player.getUniqueID();
         switch (event.reason) {
             case LOGIN:
-            case RESPAWN:
-            case DIMENSION_CHANGE:
-            case CLONE:
                 getOrCreatePlayerState(playerUUID);
                 syncPlayerState(playerUUID);
                 break;
+            case RESPAWN:
+                getOrCreatePlayerState(playerUUID);
+                cleanupPlayerState(playerUUID, "player-respawn", false);
+                break;
+            case DIMENSION_CHANGE:
+                getOrCreatePlayerState(playerUUID);
+                cleanupPlayerState(playerUUID, "player-dimension-change", false);
+                break;
+            case CLONE:
+                getOrCreatePlayerState(playerUUID);
+                cleanupPlayerState(playerUUID, "player-clone", false);
+                break;
             case LOGOUT:
-                removePlayerState(playerUUID);
+                cleanupPlayerState(playerUUID, "player-logout", true);
                 break;
             default:
                 break;


### PR DESCRIPTION
- 收敛 ChainStateService 的生命周期清理入口，补齐重生、切维度、克隆和退出时的运行态清理
- 将执行器、状态同步和掉落释放路径改为基于单次会话快照访问，避免 session 被并发清理后再次解引用
- 为并行规划任务增加会话身份校验，阻止旧 session 在后台线程继续污染新会话状态