### PR TITLE
fix: support new ore api in gtnh 2.9

### DIFF
--- a/src/main/java/club/heiqi/qz_miner/compat/adapter/CompatAdapters.java
+++ b/src/main/java/club/heiqi/qz_miner/compat/adapter/CompatAdapters.java
@@ -167,7 +167,7 @@ public final class CompatAdapters {
 
     private static List<OreCompatAdapter> createOreAdapters() {
         List<OreCompatAdapter> adapters = new ArrayList<OreCompatAdapter>();
-        addOreAdapterIfAvailable(adapters, new NamedClassOreCompatAdapter("gregtech.common.blocks.BlockOresAbstract", "gregtech.common.blocks.TileEntityOres"));
+        addOreAdapterIfAvailable(adapters, new NamedClassOreCompatAdapter("gregtech.common.blocks.GTBlockOre", null));
         addOreAdapterIfAvailable(adapters, new NamedClassOreCompatAdapter("bartworks.system.material.BWMetaGeneratedSmallOres", null));
         addOreAdapterIfAvailable(adapters, new NamedClassOreCompatAdapter("bartworks.system.material.BWMetaGeneratedOres", null));
         addOreAdapterIfAvailable(adapters, new NamedClassOreCompatAdapter(null, "bartworks.system.material.BWTileEntityMetaGeneratedOre"));


### PR DESCRIPTION
fixes: #241

Changed in: https://github.com/GTNewHorizons/GT5-Unofficial/pull/4984